### PR TITLE
Add read concern configuration to Safe{}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-go_import_path: github.com/domodwyer/mgo
+go_import_path: github.com/globalsign/mgo
 
 addons:
     apt:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/domodwyer/mgo.svg?branch=master)](https://travis-ci.org/domodwyer/mgo) [![GoDoc](https://godoc.org/github.com/domodwyer/mgo?status.svg)](https://godoc.org/github.com/domodwyer/mgo)
+[![Build Status](https://travis-ci.org/domodwyer/mgo.svg?branch=master)](https://travis-ci.org/domodwyer/mgo) [![GoDoc](https://godoc.org/github.com/globalsign/mgo?status.svg)](https://godoc.org/github.com/globalsign/mgo)
 
 The MongoDB driver for Go
 -------------------------

--- a/auth.go
+++ b/auth.go
@@ -34,8 +34,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/domodwyer/mgo/bson"
-	"github.com/domodwyer/mgo/internal/scram"
+	"github.com/globalsign/mgo/bson"
+	"github.com/globalsign/mgo/internal/scram"
 )
 
 type authCmd struct {

--- a/auth_test.go
+++ b/auth_test.go
@@ -38,7 +38,7 @@ import (
 	"sync"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 	. "gopkg.in/check.v1"
 )
 

--- a/bson/bson_corpus_spec_test.go
+++ b/bson/bson_corpus_spec_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/bson/bson_corpus_spec_test_generator.go
+++ b/bson/bson_corpus_spec_test_generator.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/domodwyer/mgo/internal/json"
+	"github.com/globalsign/mgo/internal/json"
 )
 
 func main() {
@@ -162,7 +162,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-    "github.com/domodwyer/mgo/bson"
+    "github.com/globalsign/mgo/bson"
 )
 
 func testValid(c *C, in []byte, expected []byte, result interface{}) {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -37,7 +37,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/bson/decimal_test.go
+++ b/bson/decimal_test.go
@@ -33,7 +33,7 @@ import (
     "regexp"
     "strings"
 
-    "github.com/domodwyer/mgo/bson"
+    "github.com/globalsign/mgo/bson"
 
     . "gopkg.in/check.v1"
 )

--- a/bson/json.go
+++ b/bson/json.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/domodwyer/mgo/internal/json"
+	"github.com/globalsign/mgo/internal/json"
 )
 
 // UnmarshalJSON unmarshals a JSON value that may hold non-standard

--- a/bson/json_test.go
+++ b/bson/json_test.go
@@ -1,7 +1,7 @@
 package bson_test
 
 import (
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 
 	"reflect"
 	"strings"

--- a/bulk.go
+++ b/bulk.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 // Bulk represents an operation that can be prepared with several

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -27,7 +27,7 @@
 package mgo_test
 
 import (
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 	. "gopkg.in/check.v1"
 )
 

--- a/cluster.go
+++ b/cluster.go
@@ -35,7 +35,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 // ---------------------------------------------------------------------------

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -34,8 +34,8 @@ import (
 	"sync"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 	"gopkg.in/tomb.v2"
 )
 

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 	. "gopkg.in/check.v1"
 
-	"github.com/domodwyer/mgo/dbtest"
+	"github.com/globalsign/mgo/dbtest"
 )
 
 type M map[string]interface{}

--- a/gridfs.go
+++ b/gridfs.go
@@ -36,7 +36,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 type GridFS struct {

--- a/gridfs_test.go
+++ b/gridfs_test.go
@@ -31,8 +31,8 @@ import (
 	"os"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/internal/scram/scram_test.go
+++ b/internal/scram/scram_test.go
@@ -6,7 +6,7 @@ import (
 
 	"strings"
 
-	"github.com/domodwyer/mgo/internal/scram"
+	"github.com/globalsign/mgo/internal/scram"
 	. "gopkg.in/check.v1"
 )
 

--- a/saslimpl.go
+++ b/saslimpl.go
@@ -3,7 +3,7 @@
 package mgo
 
 import (
-	"github.com/domodwyer/mgo/internal/sasl"
+	"github.com/globalsign/mgo/internal/sasl"
 )
 
 func saslNew(cred Credential, host string) (saslStepper, error) {

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 // ---------------------------------------------------------------------------

--- a/session.go
+++ b/session.go
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 type Mode int
@@ -1889,6 +1889,7 @@ func (s *Session) SetPrefetch(p float64) {
 type Safe struct {
 	W        int    // Min # of servers to ack before success
 	WMode    string // Write mode for MongoDB 2.0+ (e.g. "majority")
+	RMode    string // Read mode for MonogDB 3.2+ ("majority", "local", "linearizable")
 	WTimeout int    // Milliseconds to wait for W before timing out
 	FSync    bool   // Sync via the journal if present, or via data files sync otherwise
 	J        bool   // Sync via the journal if present
@@ -1980,6 +1981,7 @@ func (s *Session) Safe() (safe *Safe) {
 //
 // Relevant documentation:
 //
+//     https://docs.mongodb.com/manual/reference/read-concern/
 //     http://www.mongodb.org/display/DOCS/getLastError+Command
 //     http://www.mongodb.org/display/DOCS/Verifying+Propagation+of+Writes+with+getLastError
 //     http://www.mongodb.org/display/DOCS/Data+Center+Awareness
@@ -1998,6 +2000,7 @@ func (s *Session) SetSafe(safe *Safe) {
 // That is:
 //
 //     - safe.WMode is always used if set.
+//     - safe.RMode is always used if set.
 //     - safe.W is used if larger than the current W and WMode is empty.
 //     - safe.FSync is always used if true.
 //     - safe.J is used if FSync is false.
@@ -2034,6 +2037,13 @@ func (s *Session) ensureSafe(safe *Safe) {
 		w = safe.WMode
 	} else if safe.W > 0 {
 		w = safe.W
+	}
+
+	// Set the read concern
+	switch safe.RMode {
+	case "majority", "local", "linearizable":
+		s.queryConfig.op.readConcern = safe.RMode
+	default:
 	}
 
 	var cmd getLastError
@@ -3284,7 +3294,9 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 		Snapshot:    op.options.Snapshot,
 		OplogReplay: op.flags&flagLogReplay != 0,
 		Collation:   op.options.Collation,
+		ReadConcern: readLevel{level: op.readConcern},
 	}
+
 	if op.limit < 0 {
 		find.BatchSize = -op.limit
 		find.SingleBatch = true
@@ -3334,7 +3346,7 @@ type findCmd struct {
 	Comment             string      `bson:"comment,omitempty"`
 	MaxScan             int         `bson:"maxScan,omitempty"`
 	MaxTimeMS           int         `bson:"maxTimeMS,omitempty"`
-	ReadConcern         interface{} `bson:"readConcern,omitempty"`
+	ReadConcern         readLevel   `bson:"readConcern,omitempty"`
 	Max                 interface{} `bson:"max,omitempty"`
 	Min                 interface{} `bson:"min,omitempty"`
 	ReturnKey           bool        `bson:"returnKey,omitempty"`
@@ -3346,6 +3358,12 @@ type findCmd struct {
 	NoCursorTimeout     bool        `bson:"noCursorTimeout,omitempty"`
 	AllowPartialResults bool        `bson:"allowPartialResults,omitempty"`
 	Collation           *Collation  `bson:"collation,omitempty"`
+}
+
+// readLevel provides the nested "level: majority" serialisation needed for the
+// query read concern.
+type readLevel struct {
+	level string `bson:"level,omitempty"`
 }
 
 // getMoreCmd holds the command used for requesting more query results on MongoDB 3.2+.

--- a/session.go
+++ b/session.go
@@ -1901,7 +1901,7 @@ func (s *Session) Safe() (safe *Safe) {
 	defer s.m.Unlock()
 	if s.safeOp != nil {
 		cmd := s.safeOp.query.(*getLastError)
-		safe = &Safe{WTimeout: cmd.WTimeout, FSync: cmd.FSync, J: cmd.J}
+		safe = &Safe{WTimeout: cmd.WTimeout, FSync: cmd.FSync, J: cmd.J, RMode: s.queryConfig.op.readConcern}
 		switch w := cmd.W.(type) {
 		case string:
 			safe.WMode = w

--- a/session_test.go
+++ b/session_test.go
@@ -38,8 +38,8 @@ import (
 	"testing"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 
@@ -2781,6 +2781,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe := session.Safe()
 	c.Assert(safe.W, Equals, 0)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 0)
 	c.Assert(safe.FSync, Equals, false)
 	c.Assert(safe.J, Equals, false)
@@ -2790,6 +2791,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 1)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 2)
 	c.Assert(safe.FSync, Equals, true)
 	c.Assert(safe.J, Equals, false)
@@ -2799,6 +2801,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 0)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 0)
 	c.Assert(safe.FSync, Equals, false)
 	c.Assert(safe.J, Equals, false)
@@ -2808,6 +2811,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 5)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 6)
 	c.Assert(safe.FSync, Equals, false)
 	c.Assert(safe.J, Equals, true)
@@ -2817,6 +2821,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 5)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 6)
 	c.Assert(safe.FSync, Equals, false)
 	c.Assert(safe.J, Equals, true)
@@ -2826,6 +2831,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 6)
 	c.Assert(safe.WMode, Equals, "")
+	c.Assert(safe.RMode, Equals, "")
 	c.Assert(safe.WTimeout, Equals, 4)
 	c.Assert(safe.FSync, Equals, true)
 	c.Assert(safe.J, Equals, false)
@@ -2835,6 +2841,17 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 0)
 	c.Assert(safe.WMode, Equals, "majority")
+	c.Assert(safe.RMode, Equals, "")
+	c.Assert(safe.WTimeout, Equals, 2)
+	c.Assert(safe.FSync, Equals, true)
+	c.Assert(safe.J, Equals, false)
+
+	// Read concern
+	session.EnsureSafe(&mgo.Safe{RMode: "majority"})
+	safe = session.Safe()
+	c.Assert(safe.W, Equals, 0)
+	c.Assert(safe.WMode, Equals, "majority")
+	c.Assert(safe.RMode, Equals, "majority")
 	c.Assert(safe.WTimeout, Equals, 2)
 	c.Assert(safe.FSync, Equals, true)
 	c.Assert(safe.J, Equals, false)
@@ -2844,6 +2861,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 0)
 	c.Assert(safe.WMode, Equals, "something")
+	c.Assert(safe.RMode, Equals, "majority")
 	c.Assert(safe.WTimeout, Equals, 2)
 	c.Assert(safe.FSync, Equals, true)
 	c.Assert(safe.J, Equals, false)
@@ -2853,6 +2871,7 @@ func (s *S) TestSafeSetting(c *C) {
 	safe = session.Safe()
 	c.Assert(safe.W, Equals, 0)
 	c.Assert(safe.WMode, Equals, "something")
+	c.Assert(safe.RMode, Equals, "majority")
 	c.Assert(safe.WTimeout, Equals, 2)
 	c.Assert(safe.FSync, Equals, true)
 	c.Assert(safe.J, Equals, false)
@@ -2863,6 +2882,7 @@ func (s *S) TestSafeSetting(c *C) {
 	clone.EnsureSafe(&mgo.Safe{WMode: "foo"})
 	safe = session.Safe()
 	c.Assert(safe.WMode, Equals, "something")
+	c.Assert(safe.RMode, Equals, "majority")
 }
 
 func (s *S) TestSafeInsert(c *C) {

--- a/socket.go
+++ b/socket.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 type replyFunc func(err error, reply *replyOp, docNum int, docData []byte)
@@ -67,17 +67,18 @@ const (
 )
 
 type queryOp struct {
-	query      interface{}
-	collection string
-	serverTags []bson.D
-	selector   interface{}
-	replyFunc  replyFunc
-	mode       Mode
-	skip       int32
-	limit      int32
-	options    queryWrapper
-	hasOptions bool
-	flags      queryOpFlags
+	query       interface{}
+	collection  string
+	serverTags  []bson.D
+	selector    interface{}
+	replyFunc   replyFunc
+	mode        Mode
+	skip        int32
+	limit       int32
+	options     queryWrapper
+	hasOptions  bool
+	flags       queryOpFlags
+	readConcern string
 }
 
 type queryWrapper struct {

--- a/suite_test.go
+++ b/suite_test.go
@@ -38,8 +38,8 @@ import (
 	"testing"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/txn/debug.go
+++ b/txn/debug.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 var (

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -3,9 +3,9 @@ package txn
 import (
 	"fmt"
 
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 func flush(r *Runner, t *transaction) error {

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -5,10 +5,10 @@ import (
 	"math/rand"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
-	"github.com/domodwyer/mgo/dbtest"
-	"github.com/domodwyer/mgo/txn"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/globalsign/mgo/dbtest"
+	"github.com/globalsign/mgo/txn"
 	. "gopkg.in/check.v1"
 )
 

--- a/txn/tarjan.go
+++ b/txn/tarjan.go
@@ -3,7 +3,7 @@ package txn
 import (
 	"sort"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 )
 
 func tarjanSort(successors map[bson.ObjectId][]bson.ObjectId) [][]bson.ObjectId {

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -3,7 +3,7 @@ package txn
 import (
 	"fmt"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
 )
 

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"sync"
 
-	mgo "github.com/domodwyer/mgo"
+	mgo "github.com/globalsign/mgo"
 
-	"github.com/domodwyer/mgo/bson"
+	"github.com/globalsign/mgo/bson"
 
 	crand "crypto/rand"
 	mrand "math/rand"

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	mgo "github.com/domodwyer/mgo"
-	"github.com/domodwyer/mgo/bson"
-	"github.com/domodwyer/mgo/dbtest"
-	"github.com/domodwyer/mgo/txn"
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/globalsign/mgo/dbtest"
+	"github.com/globalsign/mgo/txn"
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
Allows setting the read concern for queries (https://docs.mongodb.com/manual/reference/read-concern/).

Follows existing API style:
```
session.SetSafe(&mgo.Safe{WMode: "majority", RMode: "majority"})
```

Merged in development so includes #1 in the diff.