### PR TITLE
Hide deprecated warnings when building internal/sasl package

### DIFF
--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -8,6 +8,7 @@
 package sasl
 
 // #cgo LDFLAGS: -lsasl2
+// #cgo CFLAGS: -Wno-deprecated-declarations
 //
 // struct sasl_conn {};
 //


### PR DESCRIPTION
Merge https://github.com/go-mgo/mgo/pull/450 from @drichelson.

@drichelson if you'd rather we didn't pull this, please let me know and we'll sort something out - otherwise, thanks for the contribution!