### PR TITLE
Fix decoding timezone

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -575,7 +575,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		if i == -62135596800000 {
 			in = time.Time{} // In UTC for convenience.
 		} else {
-			in = time.Unix(i/1e3, i%1e3*1e6)
+			in = time.Unix(i/1e3, i%1e3*1e6).UTC()
 		}
 	case 0x0A: // Nil
 		in = nil


### PR DESCRIPTION
mgo has an inconsistent behaviour with times indeed (_see #13 and go-mgo/mgo#362_). 

When you fetch UTC time value from MongoDB, mgo decodes it to the local time. I fixed it with returning the time in UTC instead. So, anyone can convert it to their timezone if they want.