### PR TITLE
Run integration tests against 3.2.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
         - GO=1.6   MONGODB=x86_64-3.2.12
         - GO=1.7   MONGODB=x86_64-3.2.12
         - GO=1.8.x MONGODB=x86_64-3.2.12
+        - GO=1.6   MONGODB=x86_64-3.2.16
+        - GO=1.7   MONGODB=x86_64-3.2.16
+        - GO=1.8.x MONGODB=x86_64-3.2.16
 
 install:
     - eval "$(gimme $GO)"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Further PR's (with tests) are welcome, but please maintain backwards compatibili
 * Hides SASL warnings ([details](https://github.com/globalsign/mgo/pull/7))
 * Support for partial indexes ([detials](https://github.com/domodwyer/mgo/commit/5efe8eccb028238d93c222828cae4806aeae9f51))
 * Fixes timezone handling ([details](https://github.com/go-mgo/mgo/pull/464)) 
-* Integration tests run against newest MongoDB 3.2 releases ([details](https://github.com/globalsign/mgo/pull/4))
+* Integration tests run against newest MongoDB 3.2 releases ([details](https://github.com/globalsign/mgo/pull/4), [more](https://github.com/globalsign/mgo/pull/24))
 * Improved multi-document transaction performance ([details](https://github.com/globalsign/mgo/pull/10), [more](https://github.com/globalsign/mgo/pull/11), [more](https://github.com/globalsign/mgo/pull/16))
 * Fixes cursor timeouts ([detials](https://jira.mongodb.org/browse/SERVER-24899))
 * Support index hints and timeouts for count queries ([details](https://github.com/globalsign/mgo/pull/17))


### PR DESCRIPTION
Add Go 1.6, 1.7 and 1.8 tests running against 3.2.16.