### PR TITLE
add DropAllIndexes() method

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -3478,6 +3478,31 @@ func (s *S) TestEnsureIndexDropIndexName(c *C) {
 	c.Assert(err, ErrorMatches, "index not found.*")
 }
 
+func (s *S) TestEnsureIndexDropAllIndexes(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll")
+
+	err = coll.EnsureIndexKey("a")
+	c.Assert(err, IsNil)
+
+	err = coll.EnsureIndexKey("b")
+	c.Assert(err, IsNil)
+
+	err = coll.DropAllIndexes()
+	c.Assert(err, IsNil)
+
+	sysidx := session.DB("mydb").C("system.indexes")
+
+	err = sysidx.Find(M{"name": "a_1"}).One(nil)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+
+	err = sysidx.Find(M{"name": "b_1"}).One(nil)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+}
+
 func (s *S) TestEnsureIndexCaching(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Create a new method to drop all the indexes of a collection in a single call. 

Currently, the documentation says ( in [`Indexes`](https://godoc.org/github.com/globalsign/mgo#Collection.Indexes) ): 

> For example, this snippet would drop all available indexes:
> 
> ```
> indexes, err := collection.Indexes()
> if err != nil {
>     return err
> }
> for _, index := range indexes {
>     err = collection.DropIndex(index.Key...)
>     if err != nil {
>         return err
>     }
> }
> ```

But this code fails as it tries to delete all indexes, including index on **`_id`**, which can't be deleted. 

The correct way to achieve this is : 

`err := db.Run(bson.D{{"dropIndexes", c.Name}, {"index", "*"}}, &result)`

This PR remove the code sample from  [`Indexes`](https://godoc.org/github.com/globalsign/mgo#Collection.Indexes) documentation, and provide a new method `DropIndexes()` which is a wrapper around above command 