### PR TITLE
fix golint, go vet and go fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,11 @@ install:
     - go get gopkg.in/check.v1
     - go get gopkg.in/yaml.v2
     - go get gopkg.in/tomb.v2
+    - go get github.com/golang/lint/golint
 
 before_script:
+    - golint  ./... | grep -v 'ID' | cat
+    - go vet github.com/globalsign/mgo/bson github.com/globalsign/mgo/txn github.com/globalsign/mgo 
     - export NOIPV6=1
     - make startdb
 

--- a/auth.go
+++ b/auth.go
@@ -61,7 +61,7 @@ type getNonceCmd struct {
 
 type getNonceResult struct {
 	Nonce string
-	Err   string "$err"
+	Err   string `bson:"$err"`
 	Code  int
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -580,7 +580,7 @@ func (s *S) TestAuthLoginCachingWithNewSession(c *C) {
 }
 
 func (s *S) TestAuthLoginCachingAcrossPool(c *C) {
-	// Logins are cached even when the conenction goes back
+	// Logins are cached even when the connection goes back
 	// into the pool.
 
 	session, err := mgo.Dial("localhost:40002")
@@ -934,7 +934,7 @@ func (s *S) TestAuthX509Cred(c *C) {
 	x509Subject := "CN=localhost,OU=Client,O=MGO,L=MGO,ST=MGO,C=GO"
 
 	externalDB := session.DB("$external")
-	var x509User mgo.User = mgo.User{
+	var x509User = mgo.User{
 		Username:     x509Subject,
 		OtherDBRoles: map[string][]mgo.Role{"admin": {mgo.RoleRoot}},
 	}
@@ -1080,11 +1080,11 @@ func (kerberosSuite *KerberosSuite) TestAuthKerberosURL(c *C) {
 		c.Skip("no -kerberos")
 	}
 	c.Logf("Connecting to %s...", kerberosHost)
-	connectUri := url.QueryEscape(kerberosUser) + "@" + kerberosHost + "?authMechanism=GSSAPI"
+	connectURI := url.QueryEscape(kerberosUser) + "@" + kerberosHost + "?authMechanism=GSSAPI"
 	if runtime.GOOS == "windows" {
-		connectUri = url.QueryEscape(kerberosUser) + ":" + url.QueryEscape(getWindowsKerberosPassword()) + "@" + kerberosHost + "?authMechanism=GSSAPI"
+		connectURI = url.QueryEscape(kerberosUser) + ":" + url.QueryEscape(getWindowsKerberosPassword()) + "@" + kerberosHost + "?authMechanism=GSSAPI"
 	}
-	session, err := mgo.Dial(connectUri)
+	session, err := mgo.Dial(connectURI)
 	c.Assert(err, IsNil)
 	defer session.Close()
 	n, err := session.DB("kerberos").C("test").Find(M{}).Count()

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -134,13 +134,13 @@ var allItems = []testItemType{
 		"\x04_\x00\r\x00\x00\x00\x080\x00\x01\x081\x00\x00\x00"},
 	{bson.M{"_": []byte("yo")},
 		"\x05_\x00\x02\x00\x00\x00\x00yo"},
-	{bson.M{"_": bson.Binary{0x80, []byte("udef")}},
+	{bson.M{"_": bson.Binary{Kind: 0x80, Data: []byte("udef")}},
 		"\x05_\x00\x04\x00\x00\x00\x80udef"},
 	{bson.M{"_": bson.Undefined}, // Obsolete, but still seen in the wild.
 		"\x06_\x00"},
 	{bson.M{"_": bson.ObjectId("0123456789ab")},
 		"\x07_\x000123456789ab"},
-	{bson.M{"_": bson.DBPointer{"testnamespace", bson.ObjectId("0123456789ab")}},
+	{bson.M{"_": bson.DBPointer{Namespace: "testnamespace", Id: bson.ObjectId("0123456789ab")}},
 		"\x0C_\x00\x0e\x00\x00\x00testnamespace\x000123456789ab"},
 	{bson.M{"_": false},
 		"\x08_\x00\x00"},
@@ -150,13 +150,13 @@ var allItems = []testItemType{
 		"\x09_\x00\x02\x01\x00\x00\x00\x00\x00\x00"},
 	{bson.M{"_": nil},
 		"\x0A_\x00"},
-	{bson.M{"_": bson.RegEx{"ab", "cd"}},
+	{bson.M{"_": bson.RegEx{Pattern: "ab", Options: "cd"}},
 		"\x0B_\x00ab\x00cd\x00"},
-	{bson.M{"_": bson.JavaScript{"code", nil}},
+	{bson.M{"_": bson.JavaScript{Code: "code", Scope: nil}},
 		"\x0D_\x00\x05\x00\x00\x00code\x00"},
 	{bson.M{"_": bson.Symbol("sym")},
 		"\x0E_\x00\x04\x00\x00\x00sym\x00"},
-	{bson.M{"_": bson.JavaScript{"code", bson.M{"": nil}}},
+	{bson.M{"_": bson.JavaScript{Code: "code", Scope: bson.M{"": nil}}},
 		"\x0F_\x00\x14\x00\x00\x00\x05\x00\x00\x00code\x00" +
 			"\x07\x00\x00\x00\x0A\x00\x00"},
 	{bson.M{"_": 258},
@@ -200,7 +200,7 @@ func (s *S) TestUnmarshalRawAllItems(c *C) {
 			continue
 		}
 		pv := reflect.New(reflect.ValueOf(value).Type())
-		raw := bson.Raw{item.data[0], []byte(item.data[3:])}
+		raw := bson.Raw{Kind: item.data[0], Data: []byte(item.data[3:])}
 		c.Logf("Unmarshal raw: %#v, %#v", raw, pv.Interface())
 		err := raw.Unmarshal(pv.Interface())
 		c.Assert(err, IsNil)
@@ -209,7 +209,7 @@ func (s *S) TestUnmarshalRawAllItems(c *C) {
 }
 
 func (s *S) TestUnmarshalRawIncompatible(c *C) {
-	raw := bson.Raw{0x08, []byte{0x01}} // true
+	raw := bson.Raw{Kind: 0x08, Data: []byte{0x01}} // true
 	err := raw.Unmarshal(&struct{}{})
 	c.Assert(err, ErrorMatches, "BSON kind 0x08 isn't compatible with type struct \\{\\}")
 }
@@ -258,15 +258,15 @@ func (s *S) TestMarshalBuffer(c *C) {
 
 var oneWayMarshalItems = []testItemType{
 	// These are being passed as pointers, and will unmarshal as values.
-	{bson.M{"": &bson.Binary{0x02, []byte("old")}},
+	{bson.M{"": &bson.Binary{Kind: 0x02, Data: []byte("old")}},
 		"\x05\x00\x07\x00\x00\x00\x02\x03\x00\x00\x00old"},
-	{bson.M{"": &bson.Binary{0x80, []byte("udef")}},
+	{bson.M{"": &bson.Binary{Kind: 0x80, Data: []byte("udef")}},
 		"\x05\x00\x04\x00\x00\x00\x80udef"},
-	{bson.M{"": &bson.RegEx{"ab", "cd"}},
+	{bson.M{"": &bson.RegEx{Pattern: "ab", Options: "cd"}},
 		"\x0B\x00ab\x00cd\x00"},
-	{bson.M{"": &bson.JavaScript{"code", nil}},
+	{bson.M{"": &bson.JavaScript{Code: "code", Scope: nil}},
 		"\x0D\x00\x05\x00\x00\x00code\x00"},
-	{bson.M{"": &bson.JavaScript{"code", bson.M{"": nil}}},
+	{bson.M{"": &bson.JavaScript{Code: "code", Scope: bson.M{"": nil}}},
 		"\x0F\x00\x14\x00\x00\x00\x05\x00\x00\x00code\x00" +
 			"\x07\x00\x00\x00\x0A\x00\x00"},
 
@@ -283,9 +283,9 @@ var oneWayMarshalItems = []testItemType{
 		"\x04\x00\r\x00\x00\x00\x080\x00\x01\x081\x00\x00\x00"},
 
 	// Will unmarshal as a []byte.
-	{bson.M{"": bson.Binary{0x00, []byte("yo")}},
+	{bson.M{"": bson.Binary{Kind: 0x00, Data: []byte("yo")}},
 		"\x05\x00\x02\x00\x00\x00\x00yo"},
-	{bson.M{"": bson.Binary{0x02, []byte("old")}},
+	{bson.M{"": bson.Binary{Kind: 0x02, Data: []byte("old")}},
 		"\x05\x00\x07\x00\x00\x00\x02\x03\x00\x00\x00old"},
 
 	// No way to preserve the type information here. We might encode as a zero
@@ -338,7 +338,7 @@ type specSample1 struct {
 }
 
 type specSample2 struct {
-	BSON []interface{} "BSON"
+	BSON []interface{} `bson:"BSON"`
 }
 
 var structSampleItems = []testItemType{
@@ -396,7 +396,7 @@ var structItems = []testItemType{
 	{&struct{ Byte byte }{0},
 		"\x10byte\x00\x00\x00\x00\x00"},
 	{&struct {
-		V byte "Tag"
+		V byte `bson:"Tag"`
 	}{8},
 		"\x10Tag\x00\x08\x00\x00\x00"},
 	{&struct {
@@ -411,9 +411,9 @@ var structItems = []testItemType{
 	{&struct{ A, C, B, D, F, E *byte }{},
 		"\x0Aa\x00\x0Ac\x00\x0Ab\x00\x0Ad\x00\x0Af\x00\x0Ae\x00"},
 
-	{&struct{ V bson.Raw }{bson.Raw{0x03, []byte("\x0f\x00\x00\x00\x10byte\x00\b\x00\x00\x00\x00")}},
+	{&struct{ V bson.Raw }{bson.Raw{Kind: 0x03, Data: []byte("\x0f\x00\x00\x00\x10byte\x00\b\x00\x00\x00\x00")}},
 		"\x03v\x00" + "\x0f\x00\x00\x00\x10byte\x00\b\x00\x00\x00\x00"},
-	{&struct{ V bson.Raw }{bson.Raw{0x10, []byte("\x00\x00\x00\x00")}},
+	{&struct{ V bson.Raw }{bson.Raw{Kind: 0x10, Data: []byte("\x00\x00\x00\x00")}},
 		"\x10v\x00" + "\x00\x00\x00\x00"},
 
 	// Byte arrays.
@@ -438,7 +438,7 @@ func (s *S) TestUnmarshalStructItems(c *C) {
 
 func (s *S) TestUnmarshalRawStructItems(c *C) {
 	for i, item := range structItems {
-		raw := bson.Raw{0x03, []byte(wrapInDoc(item.data))}
+		raw := bson.Raw{Kind: 0x03, Data: []byte(wrapInDoc(item.data))}
 		zero := makeZeroDoc(item.obj)
 		err := raw.Unmarshal(zero)
 		c.Assert(err, IsNil)
@@ -449,7 +449,7 @@ func (s *S) TestUnmarshalRawStructItems(c *C) {
 func (s *S) TestUnmarshalRawNil(c *C) {
 	// Regression test: shouldn't try to nil out the pointer itself,
 	// as it's not settable.
-	raw := bson.Raw{0x0A, []byte{}}
+	raw := bson.Raw{Kind: 0x0A, Data: []byte{}}
 	err := raw.Unmarshal(&struct{}{})
 	c.Assert(err, IsNil)
 }
@@ -469,25 +469,25 @@ type ignoreField struct {
 
 var marshalItems = []testItemType{
 	// Ordered document dump.  Will unmarshal as a dictionary by default.
-	{bson.D{{"a", nil}, {"c", nil}, {"b", nil}, {"d", nil}, {"f", nil}, {"e", true}},
+	{bson.D{{Name: "a", Value: nil}, {Name: "c", Value: nil}, {Name: "b", Value: nil}, {Name: "d", Value: nil}, {Name: "f", Value: nil}, {Name: "e", Value: true}},
 		"\x0Aa\x00\x0Ac\x00\x0Ab\x00\x0Ad\x00\x0Af\x00\x08e\x00\x01"},
-	{MyD{{"a", nil}, {"c", nil}, {"b", nil}, {"d", nil}, {"f", nil}, {"e", true}},
+	{MyD{{Name: "a", Value: nil}, {Name: "c", Value: nil}, {Name: "b", Value: nil}, {Name: "d", Value: nil}, {Name: "f", Value: nil}, {Name: "e", Value: true}},
 		"\x0Aa\x00\x0Ac\x00\x0Ab\x00\x0Ad\x00\x0Af\x00\x08e\x00\x01"},
-	{&dOnIface{bson.D{{"a", nil}, {"c", nil}, {"b", nil}, {"d", true}}},
+	{&dOnIface{bson.D{{Name: "a", Value: nil}, {Name: "c", Value: nil}, {Name: "b", Value: nil}, {Name: "d", Value: true}}},
 		"\x03d\x00" + wrapInDoc("\x0Aa\x00\x0Ac\x00\x0Ab\x00\x08d\x00\x01")},
 
-	{bson.RawD{{"a", bson.Raw{0x0A, nil}}, {"c", bson.Raw{0x0A, nil}}, {"b", bson.Raw{0x08, []byte{0x01}}}},
+	{bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "c", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "b", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}},
 		"\x0Aa\x00" + "\x0Ac\x00" + "\x08b\x00\x01"},
-	{MyRawD{{"a", bson.Raw{0x0A, nil}}, {"c", bson.Raw{0x0A, nil}}, {"b", bson.Raw{0x08, []byte{0x01}}}},
+	{MyRawD{{Name: "a", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "c", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "b", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}},
 		"\x0Aa\x00" + "\x0Ac\x00" + "\x08b\x00\x01"},
-	{&dOnIface{bson.RawD{{"a", bson.Raw{0x0A, nil}}, {"c", bson.Raw{0x0A, nil}}, {"b", bson.Raw{0x08, []byte{0x01}}}}},
+	{&dOnIface{bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "c", Value: bson.Raw{Kind: 0x0A, Data: nil}}, {Name: "b", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}},
 		"\x03d\x00" + wrapInDoc("\x0Aa\x00"+"\x0Ac\x00"+"\x08b\x00\x01")},
 
 	{&ignoreField{"before", "ignore", "after"},
 		"\x02before\x00\a\x00\x00\x00before\x00\x02after\x00\x06\x00\x00\x00after\x00"},
 
 	// Marshalling a Raw document does nothing.
-	{bson.Raw{0x03, []byte(wrapInDoc("anything"))},
+	{bson.Raw{Kind: 0x03, Data: []byte(wrapInDoc("anything"))},
 		"anything"},
 	{bson.Raw{Data: []byte(wrapInDoc("anything"))},
 		"anything"},
@@ -536,15 +536,15 @@ var unmarshalItems = []testItemType{
 		"\x02str\x00\x02\x00\x00\x00s\x00"},
 
 	// Ordered document.
-	{&struct{ bson.D }{bson.D{{"a", nil}, {"c", nil}, {"b", nil}, {"d", true}}},
+	{&struct{ bson.D }{bson.D{{Name: "a", Value: nil}, {Name: "c", Value: nil}, {Name: "b", Value: nil}, {Name: "d", Value: true}}},
 		"\x03d\x00" + wrapInDoc("\x0Aa\x00\x0Ac\x00\x0Ab\x00\x08d\x00\x01")},
 
 	// Raw document.
-	{&bson.Raw{0x03, []byte(wrapInDoc("\x10byte\x00\x08\x00\x00\x00"))},
+	{&bson.Raw{Kind: 0x03, Data: []byte(wrapInDoc("\x10byte\x00\x08\x00\x00\x00"))},
 		"\x10byte\x00\x08\x00\x00\x00"},
 
 	// RawD document.
-	{&struct{ bson.RawD }{bson.RawD{{"a", bson.Raw{0x0A, []byte{}}}, {"c", bson.Raw{0x0A, []byte{}}}, {"b", bson.Raw{0x08, []byte{0x01}}}}},
+	{&struct{ bson.RawD }{bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x0A, Data: []byte{}}}, {Name: "c", Value: bson.Raw{Kind: 0x0A, Data: []byte{}}}, {Name: "b", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}},
 		"\x03rawd\x00" + wrapInDoc("\x0Aa\x00\x0Ac\x00\x08b\x00\x01")},
 
 	// Decode old binary.
@@ -580,7 +580,7 @@ func (s *S) TestUnmarshalNilInStruct(c *C) {
 
 type structWithDupKeys struct {
 	Name  byte
-	Other byte "name" // Tag should precede.
+	Other byte `bson:"name"` // Tag should precede.
 }
 
 var marshalErrorItems = []testItemType{
@@ -594,11 +594,11 @@ var marshalErrorItems = []testItemType{
 		"Can't marshal complex128 in a BSON document"},
 	{&structWithDupKeys{},
 		"Duplicated key 'name' in struct bson_test.structWithDupKeys"},
-	{bson.Raw{0xA, []byte{}},
+	{bson.Raw{Kind: 0xA, Data: []byte{}},
 		"Attempted to marshal Raw kind 10 as a document"},
-	{bson.Raw{0x3, []byte{}},
+	{bson.Raw{Kind: 0x3, Data: []byte{}},
 		"Attempted to marshal empty Raw document"},
-	{bson.M{"w": bson.Raw{0x3, []byte{}}},
+	{bson.M{"w": bson.Raw{Kind: 0x3, Data: []byte{}}},
 		"Attempted to marshal empty Raw document"},
 	{&inlineCantPtr{&struct{ A, B int }{1, 2}},
 		"Option ,inline needs a struct value or map field"},
@@ -646,11 +646,11 @@ var unmarshalErrorItems = []unmarshalErrorType{
 
 	{struct{ Name bool }{},
 		"\x10name\x00\x08\x00\x00\x00",
-		"Unmarshal can't deal with struct values. Use a pointer."},
+		"unmarshal can't deal with struct values. Use a pointer"},
 
 	{123,
 		"\x10name\x00\x08\x00\x00\x00",
-		"Unmarshal needs a map or a pointer to a struct."},
+		"unmarshal needs a map or a pointer to a struct"},
 
 	{nil,
 		"\x08\x62\x00\x02",
@@ -683,20 +683,20 @@ type unmarshalRawErrorType struct {
 var unmarshalRawErrorItems = []unmarshalRawErrorType{
 	// Tag name conflicts with existing parameter.
 	{&structWithDupKeys{},
-		bson.Raw{0x03, []byte("\x10byte\x00\x08\x00\x00\x00")},
+		bson.Raw{Kind: 0x03, Data: []byte("\x10byte\x00\x08\x00\x00\x00")},
 		"Duplicated key 'name' in struct bson_test.structWithDupKeys"},
 
 	{&struct{}{},
-		bson.Raw{0xEE, []byte{}},
+		bson.Raw{Kind: 0xEE, Data: []byte{}},
 		"Unknown element kind \\(0xEE\\)"},
 
 	{struct{ Name bool }{},
-		bson.Raw{0x10, []byte("\x08\x00\x00\x00")},
-		"Raw Unmarshal can't deal with struct values. Use a pointer."},
+		bson.Raw{Kind: 0x10, Data: []byte("\x08\x00\x00\x00")},
+		"raw Unmarshal can't deal with struct values. Use a pointer"},
 
 	{123,
-		bson.Raw{0x10, []byte("\x08\x00\x00\x00")},
-		"Raw Unmarshal needs a map or a valid pointer."},
+		bson.Raw{Kind: 0x10, Data: []byte("\x08\x00\x00\x00")},
+		"raw Unmarshal needs a map or a valid pointer"},
 }
 
 func (s *S) TestUnmarshalRawErrorItems(c *C) {
@@ -768,11 +768,11 @@ func (o *setterType) SetBSON(raw bson.Raw) error {
 }
 
 type ptrSetterDoc struct {
-	Field *setterType "_"
+	Field *setterType `bson:"_"`
 }
 
 type valSetterDoc struct {
-	Field setterType "_"
+	Field setterType `bson:"_"`
 }
 
 func (s *S) TestUnmarshalAllItemsWithPtrSetter(c *C) {
@@ -856,12 +856,12 @@ func (s *S) TestUnmarshalSetterErrors(c *C) {
 }
 
 func (s *S) TestDMap(c *C) {
-	d := bson.D{{"a", 1}, {"b", 2}}
+	d := bson.D{{Name: "a", Value: 1}, {Name: "b", Value: 2}}
 	c.Assert(d.Map(), DeepEquals, bson.M{"a": 1, "b": 2})
 }
 
-func (s *S) TestUnmarshalSetterSetZero(c *C) {
-	setterResult["foo"] = bson.SetZero
+func (s *S) TestUnmarshalSetterErrSetZero(c *C) {
+	setterResult["foo"] = bson.ErrSetZero
 	defer delete(setterResult, "field")
 
 	data, err := bson.Marshal(bson.M{"field": "foo"})
@@ -892,7 +892,7 @@ func (t *typeWithGetter) GetBSON() (interface{}, error) {
 }
 
 type docWithGetterField struct {
-	Field *typeWithGetter "_"
+	Field *typeWithGetter `bson:"_"`
 }
 
 func (s *S) TestMarshalAllItemsWithGetter(c *C) {
@@ -938,7 +938,7 @@ func (t intGetter) GetBSON() (interface{}, error) {
 }
 
 type typeWithIntGetter struct {
-	V intGetter ",minsize"
+	V intGetter `bson:",minsize"`
 }
 
 func (s *S) TestMarshalShortWithGetter(c *C) {
@@ -970,96 +970,96 @@ type crossTypeItem struct {
 }
 
 type condStr struct {
-	V string ",omitempty"
+	V string `bson:",omitempty"`
 }
 type condStrNS struct {
 	V string `a:"A" bson:",omitempty" b:"B"`
 }
 type condBool struct {
-	V bool ",omitempty"
+	V bool `bson:",omitempty"`
 }
 type condInt struct {
-	V int ",omitempty"
+	V int `bson:",omitempty"`
 }
 type condUInt struct {
-	V uint ",omitempty"
+	V uint `bson:",omitempty"`
 }
 type condFloat struct {
-	V float64 ",omitempty"
+	V float64 `bson:",omitempty"`
 }
 type condIface struct {
-	V interface{} ",omitempty"
+	V interface{} `bson:",omitempty"`
 }
 type condPtr struct {
-	V *bool ",omitempty"
+	V *bool `bson:",omitempty"`
 }
 type condSlice struct {
-	V []string ",omitempty"
+	V []string `bson:",omitempty"`
 }
 type condMap struct {
-	V map[string]int ",omitempty"
+	V map[string]int `bson:",omitempty"`
 }
 type namedCondStr struct {
-	V string "myv,omitempty"
+	V string `bson:"myv,omitempty"`
 }
 type condTime struct {
-	V time.Time ",omitempty"
+	V time.Time `bson:",omitempty"`
 }
 type condStruct struct {
-	V struct{ A []int } ",omitempty"
+	V struct{ A []int } `bson:",omitempty"`
 }
 type condRaw struct {
-	V bson.Raw ",omitempty"
+	V bson.Raw `bson:",omitempty"`
 }
 
 type shortInt struct {
-	V int64 ",minsize"
+	V int64 `bson:",minsize"`
 }
 type shortUint struct {
-	V uint64 ",minsize"
+	V uint64 `bson:",minsize"`
 }
 type shortIface struct {
-	V interface{} ",minsize"
+	V interface{} `bson:",minsize"`
 }
 type shortPtr struct {
-	V *int64 ",minsize"
+	V *int64 `bson:",minsize"`
 }
 type shortNonEmptyInt struct {
-	V int64 ",minsize,omitempty"
+	V int64 `bson:",minsize,omitempty"`
 }
 
 type inlineInt struct {
-	V struct{ A, B int } ",inline"
+	V struct{ A, B int } `bson:",inline"`
 }
 type inlineCantPtr struct {
-	V *struct{ A, B int } ",inline"
+	V *struct{ A, B int } `bson:",inline"`
 }
 type inlineDupName struct {
 	A int
-	V struct{ A, B int } ",inline"
+	V struct{ A, B int } `bson:",inline"`
 }
 type inlineMap struct {
 	A int
-	M map[string]interface{} ",inline"
+	M map[string]interface{} `bson:",inline"`
 }
 type inlineMapInt struct {
 	A int
-	M map[string]int ",inline"
+	M map[string]int `bson:",inline"`
 }
 type inlineMapMyM struct {
 	A int
-	M MyM ",inline"
+	M MyM `bson:",inline"`
 }
 type inlineDupMap struct {
-	M1 map[string]interface{} ",inline"
-	M2 map[string]interface{} ",inline"
+	M1 map[string]interface{} `bson:",inline"`
+	M2 map[string]interface{} `bson:",inline"`
 }
 type inlineBadKeyMap struct {
-	M map[int]int ",inline"
+	M map[int]int `bson:",inline"`
 }
 type inlineUnexported struct {
-	M          map[string]interface{} ",inline"
-	unexported ",inline"
+	M          map[string]interface{} `bson:",inline"`
+	unexported `bson:",inline"`
 }
 type unexported struct {
 	A int
@@ -1077,7 +1077,7 @@ func (s getterSetterD) GetBSON() (interface{}, error) {
 func (s *getterSetterD) SetBSON(raw bson.Raw) error {
 	var doc bson.D
 	err := raw.Unmarshal(&doc)
-	doc = append(doc, bson.DocElem{"suffix", true})
+	doc = append(doc, bson.DocElem{Name: "suffix", Value: true})
 	*s = getterSetterD(doc)
 	return err
 }
@@ -1085,7 +1085,7 @@ func (s *getterSetterD) SetBSON(raw bson.Raw) error {
 type getterSetterInt int
 
 func (i getterSetterInt) GetBSON() (interface{}, error) {
-	return bson.D{{"a", int(i)}}, nil
+	return bson.D{{Name: "a", Value: int(i)}}, nil
 }
 
 func (i *getterSetterInt) SetBSON(raw bson.Raw) error {
@@ -1324,13 +1324,13 @@ var twoWayCrossItems = []crossTypeItem{
 		map[string]interface{}{"v": time.Unix(-62135596799, 1e6).Local()}},
 
 	// bson.D <=> []DocElem
-	{&bson.D{{"a", bson.D{{"b", 1}, {"c", 2}}}}, &bson.D{{"a", bson.D{{"b", 1}, {"c", 2}}}}},
-	{&bson.D{{"a", bson.D{{"b", 1}, {"c", 2}}}}, &MyD{{"a", MyD{{"b", 1}, {"c", 2}}}}},
-	{&struct{ V MyD }{MyD{{"a", 1}}}, &bson.D{{"v", bson.D{{"a", 1}}}}},
+	{&bson.D{{Name: "a", Value: bson.D{{Name: "b", Value: 1}, {Name: "c", Value: 2}}}}, &bson.D{{Name: "a", Value: bson.D{{Name: "b", Value: 1}, {Name: "c", Value: 2}}}}},
+	{&bson.D{{Name: "a", Value: bson.D{{Name: "b", Value: 1}, {Name: "c", Value: 2}}}}, &MyD{{Name: "a", Value: MyD{{Name: "b", Value: 1}, {Name: "c", Value: 2}}}}},
+	{&struct{ V MyD }{MyD{{Name: "a", Value: 1}}}, &bson.D{{Name: "v", Value: bson.D{{Name: "a", Value: 1}}}}},
 
 	// bson.RawD <=> []RawDocElem
-	{&bson.RawD{{"a", bson.Raw{0x08, []byte{0x01}}}}, &bson.RawD{{"a", bson.Raw{0x08, []byte{0x01}}}}},
-	{&bson.RawD{{"a", bson.Raw{0x08, []byte{0x01}}}}, &MyRawD{{"a", bson.Raw{0x08, []byte{0x01}}}}},
+	{&bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}, &bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}},
+	{&bson.RawD{{Name: "a", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}, &MyRawD{{Name: "a", Value: bson.Raw{Kind: 0x08, Data: []byte{0x01}}}}},
 
 	// bson.M <=> map
 	{bson.M{"a": bson.M{"b": 1, "c": 2}}, MyM{"a": MyM{"b": 1, "c": 2}}},
@@ -1345,8 +1345,8 @@ var twoWayCrossItems = []crossTypeItem{
 	{&struct{ N json.Number }{"9223372036854776000"}, map[string]interface{}{"n": float64(1 << 63)}},
 
 	// bson.D <=> non-struct getter/setter
-	{&bson.D{{"a", 1}}, &getterSetterD{{"a", 1}, {"suffix", true}}},
-	{&bson.D{{"a", 42}}, &gsintvar},
+	{&bson.D{{Name: "a", Value: 1}}, &getterSetterD{{Name: "a", Value: 1}, {Name: "suffix", Value: true}}},
+	{&bson.D{{Name: "a", Value: 42}}, &gsintvar},
 
 	// Interface slice setter.
 	{&struct{ V ifaceSlice }{ifaceSlice{nil, nil, nil}}, bson.M{"v": []interface{}{3}}},
@@ -1368,7 +1368,7 @@ var oneWayCrossItems = []crossTypeItem{
 
 	// Ensure omitempty on struct with private fields works properly.
 	{&struct {
-		V struct{ v time.Time } ",omitempty"
+		V struct{ v time.Time } `bson:",omitempty"`
 	}{}, map[string]interface{}{}},
 
 	// Attempt to marshal slice into RawD (issue #120).

--- a/bson/decimal.go
+++ b/bson/decimal.go
@@ -144,6 +144,8 @@ func dErr(s string) (Decimal128, error) {
 	return dNaN, fmt.Errorf("cannot parse %q as a decimal128", s)
 }
 
+// ParseDecimal128 parse a string and return the corresponding value as
+// a decimal128
 func ParseDecimal128(s string) (Decimal128, error) {
 	orig := s
 	if s == "" {

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -457,7 +457,7 @@ func (d *decoder) dropElem(kind byte) {
 		}
 		d.i += l
 	case 0x06: // undefined
-	case 0x07: // objectID
+	case 0x07: // objectId
 		d.i += 12
 	case 0x08:
 		k := d.readByte()
@@ -629,7 +629,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 
 	if setter := getSetter(outt, out); setter != nil {
 		err := setter.SetBSON(Raw{kind, d.in[start:d.i]})
-		if err == SetZero {
+		if err == ErrSetZero {
 			out.Set(reflect.Zero(outt))
 			return true
 		}

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -331,7 +331,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			// Stored as int64
 			e.addElemName(0x12, name)
 
-			e.addInt64(int64(v.Int()/1e6))
+			e.addInt64(int64(v.Int() / 1e6))
 		default:
 			i := v.Int()
 			if (minSize || v.Type().Kind() != reflect.Int64) && i >= math.MinInt32 && i <= math.MaxInt32 {

--- a/bson/json_test.go
+++ b/bson/json_test.go
@@ -65,7 +65,7 @@ var jsonTests = []jsonTest{
 
 	// $regex
 	{
-		a: bson.RegEx{"pattern", "options"},
+		a: bson.RegEx{Pattern: "pattern", Options: "options"},
 		b: `{"$regex":"pattern","$options":"options"}`,
 	},
 

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -64,7 +64,7 @@ func (s *S) TestBulkInsertError(c *C) {
 	c.Assert(mgo.IsDup(err), Equals, true)
 
 	type doc struct {
-		N int `_id`
+		N int `bson:"_id"`
 	}
 	var res []doc
 	err = coll.Find(nil).Sort("_id").All(&res)
@@ -85,7 +85,7 @@ func (s *S) TestBulkInsertErrorUnordered(c *C) {
 	c.Assert(err, ErrorMatches, ".*duplicate key.*")
 
 	type doc struct {
-		N int `_id`
+		N int `bson:"_id"`
 	}
 	var res []doc
 	err = coll.Find(nil).Sort("_id").All(&res)
@@ -110,7 +110,7 @@ func (s *S) TestBulkInsertErrorUnorderedSplitBatch(c *C) {
 
 	const total = 4096
 	type doc struct {
-		Id int `_id`
+		Id int `bson:"_id"`
 	}
 	docs := make([]interface{}, total)
 	for i := 0; i < total; i++ {

--- a/cluster.go
+++ b/cluster.go
@@ -157,7 +157,7 @@ func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResul
 	if cluster.appName != "" {
 		metaInfo["application"] = bson.M{"name": cluster.appName}
 	}
-	err := session.Run(bson.D{{"isMaster", 1}, {"client", metaInfo}}, result)
+	err := session.Run(bson.D{{Name: "isMaster", Value: 1}, {Name: "client", Value: metaInfo}}, result)
 	session.Close()
 	return err
 }
@@ -667,7 +667,6 @@ func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout 
 		}
 		return s, nil
 	}
-	panic("unreached")
 }
 
 func (cluster *mongoCluster) CacheIndex(cacheKey string, exists bool) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -500,7 +500,7 @@ func (s *S) TestModePrimaryHiccup(c *C) {
 		sessions[i].Close()
 	}
 
-	// Kill the master, but bring it back immediatelly.
+	// Kill the master, but bring it back immediately.
 	host := result.Host
 	s.Stop(host)
 	s.StartAll()
@@ -1526,7 +1526,7 @@ func (s *S) TestRemovalOfClusterMember(c *C) {
 			"40023": `{_id: 3, host: "127.0.0.1:40023", priority: 0, tags: {rs2: "c"}}`,
 		}
 		master.Refresh()
-		master.Run(bson.D{{"$eval", `rs.add(` + config[hostPort(slaveAddr)] + `)`}}, nil)
+		master.Run(bson.D{{Name: "$eval", Value: `rs.add(` + config[hostPort(slaveAddr)] + `)`}}, nil)
 		master.Close()
 		slave.Close()
 
@@ -1541,7 +1541,7 @@ func (s *S) TestRemovalOfClusterMember(c *C) {
 
 	c.Logf("========== Removing slave: %s ==========", slaveAddr)
 
-	master.Run(bson.D{{"$eval", `rs.remove("` + slaveAddr + `")`}}, nil)
+	master.Run(bson.D{{Name: "$eval", Value: `rs.remove("` + slaveAddr + `")`}}, nil)
 
 	master.Refresh()
 
@@ -1563,7 +1563,7 @@ func (s *S) TestRemovalOfClusterMember(c *C) {
 	}
 	live := master.LiveServers()
 	if len(live) != 2 {
-		c.Errorf("Removed server still considered live: %#s", live)
+		c.Errorf("Removed server still considered live: %v", live)
 	}
 
 	c.Log("========== Test succeeded. ==========")
@@ -1812,6 +1812,7 @@ func (s *S) TestPrimaryShutdownOnAuthShard(c *C) {
 	c.Assert(err, IsNil)
 
 	count, err := coll.Count()
+	c.Assert(err, IsNil)
 	c.Assert(count > 1, Equals, true)
 }
 
@@ -1977,13 +1978,13 @@ func (s *S) TestSelectServers(c *C) {
 	var result struct{ Host string }
 
 	session.Refresh()
-	session.SelectServers(bson.D{{"rs1", "b"}})
+	session.SelectServers(bson.D{{Name: "rs1", Value: "b"}})
 	err = session.Run("serverStatus", &result)
 	c.Assert(err, IsNil)
 	c.Assert(hostPort(result.Host), Equals, "40012")
 
 	session.Refresh()
-	session.SelectServers(bson.D{{"rs1", "c"}})
+	session.SelectServers(bson.D{{Name: "rs1", Value: "c"}})
 	err = session.Run("serverStatus", &result)
 	c.Assert(err, IsNil)
 	c.Assert(hostPort(result.Host), Equals, "40013")
@@ -2035,7 +2036,7 @@ func (s *S) TestSelectServersWithMongos(c *C) {
 	mongos.SetMode(mgo.Monotonic, true)
 
 	mongos.Refresh()
-	mongos.SelectServers(bson.D{{"rs2", slave1}})
+	mongos.SelectServers(bson.D{{Name: "rs2", Value: slave1}})
 	coll := mongos.DB("mydb").C("mycoll")
 	result := &struct{}{}
 	for i := 0; i != 5; i++ {
@@ -2044,7 +2045,7 @@ func (s *S) TestSelectServersWithMongos(c *C) {
 	}
 
 	mongos.Refresh()
-	mongos.SelectServers(bson.D{{"rs2", slave2}})
+	mongos.SelectServers(bson.D{{Name: "rs2", Value: slave2}})
 	coll = mongos.DB("mydb").C("mycoll")
 	for i := 0; i != 7; i++ {
 		err := coll.Find(nil).One(result)

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -142,7 +142,7 @@ func (dbs *DBServer) Session() *mgo.Session {
 
 // checkSessions ensures all mgo sessions opened were properly closed.
 // For slightly faster tests, it may be disabled setting the
-// environmnet variable CHECK_SESSIONS to 0.
+// environment variable CHECK_SESSIONS to 0.
 func (dbs *DBServer) checkSessions() {
 	if check := os.Getenv("CHECK_SESSIONS"); check == "0" || dbs.server == nil || dbs.session == nil {
 		return

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -78,6 +78,8 @@ func (s *S) TestStop(c *C) {
 
 	// Server should not be running anymore.
 	session, err = mgo.DialWithTimeout(addr, 500*time.Millisecond)
+	c.Assert(err, IsNil)
+
 	if session != nil {
 		session.Close()
 		c.Fatalf("Stop did not stop the server")

--- a/internal/json/decode.go
+++ b/internal/json/decode.go
@@ -899,7 +899,7 @@ func (d *decodeState) name(v reflect.Value) {
 	}
 
 	// Check for unmarshaler on func field itself.
-	u, ut, pv = d.indirect(v, false)
+	u, _, _ = d.indirect(v, false)
 	if u != nil {
 		d.off = nameStart
 		err := u.UnmarshalJSON(d.next())

--- a/internal/json/decode_test.go
+++ b/internal/json/decode_test.go
@@ -109,7 +109,7 @@ var (
 	umstructXY   = ustructText{unmarshalerText{"x", "y"}}
 
 	ummapType = map[unmarshalerText]bool{}
-	ummapXY   = map[unmarshalerText]bool{unmarshalerText{"x", "y"}: true}
+	ummapXY   = map[unmarshalerText]bool{{"x", "y"}: true}
 )
 
 // Test data structures for anonymous fields.

--- a/internal/json/encode.go
+++ b/internal/json/encode.go
@@ -209,6 +209,8 @@ func (e *UnsupportedTypeError) Error() string {
 	return "json: unsupported type: " + e.Type.String()
 }
 
+// An UnsupportedValueError is returned by Marshal when attempting
+// to encode an unsupported value.
 type UnsupportedValueError struct {
 	Value reflect.Value
 	Str   string
@@ -218,7 +220,7 @@ func (e *UnsupportedValueError) Error() string {
 	return "json: unsupported value: " + e.Str
 }
 
-// Before Go 1.2, an InvalidUTF8Error was returned by Marshal when
+// InvalidUTF8Error before Go 1.2, an InvalidUTF8Error was returned by Marshal when
 // attempting to encode a string value with invalid UTF-8 sequences.
 // As of Go 1.2, Marshal instead coerces the string to valid UTF-8 by
 // replacing invalid bytes with the Unicode replacement rune U+FFFD.
@@ -232,6 +234,8 @@ func (e *InvalidUTF8Error) Error() string {
 	return "json: invalid UTF-8 in string: " + strconv.Quote(e.S)
 }
 
+// A MarshalerError is returned by Marshal when attempting
+// to marshal an invalid JSON
 type MarshalerError struct {
 	Type reflect.Type
 	Err  error

--- a/internal/json/stream_test.go
+++ b/internal/json/stream_test.go
@@ -282,7 +282,7 @@ type decodeThis struct {
 	v interface{}
 }
 
-var tokenStreamCases []tokenStreamCase = []tokenStreamCase{
+var tokenStreamCases = []tokenStreamCase{
 	// streaming token cases
 	{json: `10`, expTokens: []interface{}{float64(10)}},
 	{json: ` [10] `, expTokens: []interface{}{

--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -26,7 +26,8 @@ import (
 	"unsafe"
 )
 
-type saslStepper interface {
+// Stepper interface for saslSession
+type Stepper interface {
 	Step(serverData []byte) (clientData []byte, done bool, err error)
 	Close()
 }
@@ -50,7 +51,8 @@ func initSASL() {
 	}
 }
 
-func New(username, password, mechanism, service, host string) (saslStepper, error) {
+// New creates a new saslSession
+func New(username, password, mechanism, service, host string) (Stepper, error) {
 	initOnce.Do(initSASL)
 	if initError != nil {
 		return nil, initError

--- a/internal/scram/scram.go
+++ b/internal/scram/scram.go
@@ -24,7 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Pacakage scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
+// Package scram implements a SCRAM-{SHA-1,etc} client per RFC5802.
 //
 // http://tools.ietf.org/html/rfc5802
 //
@@ -96,7 +96,7 @@ func (c *Client) Out() []byte {
 	return c.out.Bytes()
 }
 
-// Err returns the error that ocurred, or nil if there were no errors.
+// Err returns the error that occurred, or nil if there were no errors.
 func (c *Client) Err() error {
 	return c.err
 }
@@ -133,7 +133,7 @@ func (c *Client) Step(in []byte) bool {
 func (c *Client) step1(in []byte) error {
 	if len(c.clientNonce) == 0 {
 		const nonceLen = 6
-		buf := make([]byte, nonceLen + b64.EncodedLen(nonceLen))
+		buf := make([]byte, nonceLen+b64.EncodedLen(nonceLen))
 		if _, err := rand.Read(buf[:nonceLen]); err != nil {
 			return fmt.Errorf("cannot read random SCRAM-SHA-1 nonce from operating system: %v", err)
 		}

--- a/log.go
+++ b/log.go
@@ -34,15 +34,15 @@ import (
 // ---------------------------------------------------------------------------
 // Logging integration.
 
-// Avoid importing the log type information unnecessarily.  There's a small cost
+// LogLogger avoid importing the log type information unnecessarily.  There's a small cost
 // associated with using an interface rather than the type.  Depending on how
 // often the logger is plugged in, it would be worth using the type instead.
-type log_Logger interface {
+type logLogger interface {
 	Output(calldepth int, s string) error
 }
 
 var (
-	globalLogger log_Logger
+	globalLogger logLogger
 	globalDebug  bool
 	globalMutex  sync.Mutex
 )
@@ -53,8 +53,8 @@ var (
 // the application starts. Having raceDetector as a constant, the compiler
 // should elide the locks altogether in actual use.
 
-// Specify the *log.Logger object where log messages should be sent to.
-func SetLogger(logger log_Logger) {
+// SetLogger specify the *log.Logger object where log messages should be sent to.
+func SetLogger(logger logLogger) {
 	if raceDetector {
 		globalMutex.Lock()
 		defer globalMutex.Unlock()
@@ -62,7 +62,7 @@ func SetLogger(logger log_Logger) {
 	globalLogger = logger
 }
 
-// Enable the delivery of debug messages to the logger.  Only meaningful
+// SetDebug enable the delivery of debug messages to the logger.  Only meaningful
 // if a logger is also set.
 func SetDebug(debug bool) {
 	if raceDetector {

--- a/server.go
+++ b/server.go
@@ -143,7 +143,6 @@ func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (
 		}
 		return
 	}
-	panic("unreachable")
 }
 
 // Connect establishes a new connection to the server. This should
@@ -306,7 +305,7 @@ func (server *mongoServer) pinger(loop bool) {
 	}
 	op := queryOp{
 		collection: "admin.$cmd",
-		query:      bson.D{{"ping", 1}},
+		query:      bson.D{{Name: "ping", Value: 1}},
 		flags:      flagSlaveOk,
 		limit:      -1,
 	}

--- a/session.go
+++ b/session.go
@@ -44,23 +44,32 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// Mode read preference mode. See Eventual, Monotonic and Strong for details
+//
+// Relevant documentation on read preference modes:
+//
+//     http://docs.mongodb.org/manual/reference/read-preference/
+//
 type Mode int
 
 const (
-	// Relevant documentation on read preference modes:
-	//
-	//     http://docs.mongodb.org/manual/reference/read-preference/
-	//
-	Primary            Mode = 2 // Default mode. All operations read from the current replica set primary.
-	PrimaryPreferred   Mode = 3 // Read from the primary if available. Read from the secondary otherwise.
-	Secondary          Mode = 4 // Read from one of the nearest secondary members of the replica set.
-	SecondaryPreferred Mode = 5 // Read from one of the nearest secondaries if available. Read from primary otherwise.
-	Nearest            Mode = 6 // Read from one of the nearest members, irrespective of it being primary or secondary.
+	// Primary mode is default mode. All operations read from the current replica set primary.
+	Primary Mode = 2
+	// PrimaryPreferred mode: read from the primary if available. Read from the secondary otherwise.
+	PrimaryPreferred Mode = 3
+	// Secondary mode:  read from one of the nearest secondary members of the replica set.
+	Secondary Mode = 4
+	// SecondaryPreferred mode: read from one of the nearest secondaries if available. Read from primary otherwise.
+	SecondaryPreferred Mode = 5
+	// Nearest mode: read from one of the nearest members, irrespective of it being primary or secondary.
+	Nearest Mode = 6
 
-	// Read preference modes are specific to mgo:
-	Eventual  Mode = 0 // Same as Nearest, but may change servers between reads.
-	Monotonic Mode = 1 // Same as SecondaryPreferred before first write. Same as Primary after first write.
-	Strong    Mode = 2 // Same as Primary.
+	// Eventual mode is specific to mgo, and is same as Nearest, but may change servers between reads.
+	Eventual Mode = 0
+	// Monotonic mode is specifc to mgo, and is same as SecondaryPreferred before first write. Same as Primary after first write.
+	Monotonic Mode = 1
+	// Strong mode is specific to mgo, and is same as Primary.
+	Strong Mode = 2
 )
 
 // mgo.v3: Drop Strong mode, suffix all modes with "Mode".
@@ -84,7 +93,7 @@ type Session struct {
 	creds            []Credential
 	dialCred         *Credential
 	safeOp           *queryOp
-	cluster_         *mongoCluster
+	mgoCluster       *mongoCluster
 	slaveSocket      *mongoSocket
 	masterSocket     *mongoSocket
 	m                sync.RWMutex
@@ -93,17 +102,30 @@ type Session struct {
 	slaveOk          bool
 }
 
+// Database holds collections of documents
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/core/databases-and-collections/#databases
+//
 type Database struct {
 	Session *Session
 	Name    string
 }
 
+// Collection stores documents
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/core/databases-and-collections/#collections
+//
 type Collection struct {
 	Database *Database
 	Name     string // "collection"
 	FullName string // "db.collection"
 }
 
+// Query keeps info on the query.
 type Query struct {
 	m       sync.Mutex
 	session *Session
@@ -117,13 +139,19 @@ type query struct {
 }
 
 type getLastError struct {
-	CmdName  int         "getLastError,omitempty"
-	W        interface{} "w,omitempty"
-	WTimeout int         "wtimeout,omitempty"
-	FSync    bool        "fsync,omitempty"
-	J        bool        "j,omitempty"
+	CmdName  int         `bson:"getLastError,omitempty"`
+	W        interface{} `bson:"w,omitempty"`
+	WTimeout int         `bson:"wtimeout,omitempty"`
+	FSync    bool        `bson:"fsync,omitempty"`
+	J        bool        `bson:"j,omitempty"`
 }
 
+// Iter stores informations about a Cursor
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/
+//
 type Iter struct {
 	m              sync.Mutex
 	gotReply       sync.Cond
@@ -142,8 +170,11 @@ type Iter struct {
 }
 
 var (
+	// ErrNotFound error returned when a document could not be found
 	ErrNotFound = errors.New("not found")
-	ErrCursor   = errors.New("invalid cursor")
+	// ErrCursor error returned when trying to retrieve documents from
+	// an invalid cursor
+	ErrCursor = errors.New("invalid cursor")
 )
 
 const (
@@ -599,7 +630,7 @@ func extractURL(s string) (*urlInfo, error) {
 func newSession(consistency Mode, cluster *mongoCluster, timeout time.Duration) (session *Session) {
 	cluster.Acquire()
 	session = &Session{
-		cluster_:    cluster,
+		mgoCluster:  cluster,
 		syncTimeout: timeout,
 		sockTimeout: timeout,
 		poolLimit:   4096,
@@ -627,9 +658,24 @@ func copySession(session *Session, keepCreds bool) (s *Session) {
 	} else if session.dialCred != nil {
 		creds = []Credential{*session.dialCred}
 	}
-	scopy := *session
-	scopy.m = sync.RWMutex{}
-	scopy.creds = creds
+	scopy := Session{
+		defaultdb:        session.defaultdb,
+		sourcedb:         session.sourcedb,
+		syncTimeout:      session.syncTimeout,
+		sockTimeout:      session.sockTimeout,
+		poolLimit:        session.poolLimit,
+		consistency:      session.consistency,
+		creds:            creds,
+		dialCred:         session.dialCred,
+		safeOp:           session.safeOp,
+		mgoCluster:       session.mgoCluster,
+		slaveSocket:      session.slaveSocket,
+		masterSocket:     session.masterSocket,
+		m:                sync.RWMutex{},
+		queryConfig:      session.queryConfig,
+		bypassValidation: session.bypassValidation,
+		slaveOk:          session.slaveOk,
+	}
 	s = &scopy
 	debugf("New session %p on cluster %p (copy from %p)", s, cluster, session)
 	return s
@@ -683,9 +729,9 @@ func (db *Database) C(name string) *Collection {
 //     https://docs.mongodb.com/manual/reference/method/db.createView/
 //
 func (db *Database) CreateView(view string, source string, pipeline interface{}, collation *Collation) error {
-	command := bson.D{{"create", view}, {"viewOn", source}, {"pipeline", pipeline}}
+	command := bson.D{{Name: "create", Value: view}, {Name: "viewOn", Value: source}, {Name: "pipeline", Value: pipeline}}
 	if collation != nil {
-		command = append(command, bson.DocElem{"collation", collation})
+		command = append(command, bson.DocElem{Name: "collation", Value: collation})
 	}
 	return db.Run(command, nil)
 }
@@ -910,23 +956,51 @@ type User struct {
 	UserSource string `bson:"userSource,omitempty"`
 }
 
+// Role available role for users
+//
+// Relevant documentation:
+//
+//     http://docs.mongodb.org/manual/reference/user-privileges/
+//
 type Role string
 
 const (
-	// Relevant documentation:
-	//
-	//     http://docs.mongodb.org/manual/reference/user-privileges/
-	//
-	RoleRoot         Role = "root"
-	RoleRead         Role = "read"
-	RoleReadAny      Role = "readAnyDatabase"
-	RoleReadWrite    Role = "readWrite"
+	// RoleRoot provides access to the operations and all the resources
+	// of the readWriteAnyDatabase, dbAdminAnyDatabase, userAdminAnyDatabase,
+	// clusterAdmin roles, restore, and backup roles combined.
+	RoleRoot Role = "root"
+	// RoleRead provides the ability to read data on all non-system collections
+	// and on the following system collections: system.indexes, system.js, and
+	// system.namespaces collections on a specific database.
+	RoleRead Role = "read"
+	// RoleReadAny provides the same read-only permissions as read, except it
+	// applies to it applies to all but the local and config databases in the cluster.
+	// The role also provides the listDatabases action on the cluster as a whole.
+	RoleReadAny Role = "readAnyDatabase"
+	//RoleReadWrite provides all the privileges of the read role plus ability to modify data on
+	//all non-system collections and the system.js collection on a specific database.
+	RoleReadWrite Role = "readWrite"
+	// RoleReadWriteAny provides the same read and write permissions as readWrite, except it
+	// applies to all but the local and config databases in the cluster. The role also provides
+	// the listDatabases action on the cluster as a whole.
 	RoleReadWriteAny Role = "readWriteAnyDatabase"
-	RoleDBAdmin      Role = "dbAdmin"
-	RoleDBAdminAny   Role = "dbAdminAnyDatabase"
-	RoleUserAdmin    Role = "userAdmin"
+	// RoleDBAdmin provides all the privileges of the dbAdmin role on a specific database
+	RoleDBAdmin Role = "dbAdmin"
+	// RoleDBAdminAny provides all the privileges of the dbAdmin role on all databases
+	RoleDBAdminAny Role = "dbAdminAnyDatabase"
+	// RoleUserAdmin Provides the ability to create and modify roles and users on the
+	// current database. This role also indirectly provides superuser access to either
+	// the database or, if scoped to the admin database, the cluster. The userAdmin role
+	// allows users to grant any user any privilege, including themselves.
+	RoleUserAdmin Role = "userAdmin"
+	// RoleUserAdminAny provides the same access to user administration operations as userAdmin,
+	// except it applies to all but the local and config databases in the cluster
 	RoleUserAdminAny Role = "userAdminAnyDatabase"
+	// RoleClusterAdmin Provides the greatest cluster-management access. This role combines
+	// the privileges granted by the clusterManager, clusterMonitor, and hostManager roles.
+	// Additionally, the role provides the dropDatabase action.
 	RoleClusterAdmin Role = "clusterAdmin"
+	// TODO some roles are missing: dbOwner/clusterManager/clusterMonitor/hostManager/backup/restore
 )
 
 // UpsertUser updates the authentication credentials and the roles for
@@ -972,32 +1046,32 @@ func (db *Database) UpsertUser(user *User) error {
 	if user.Password != "" {
 		psum := md5.New()
 		psum.Write([]byte(user.Username + ":mongo:" + user.Password))
-		set = append(set, bson.DocElem{"pwd", hex.EncodeToString(psum.Sum(nil))})
-		unset = append(unset, bson.DocElem{"userSource", 1})
+		set = append(set, bson.DocElem{Name: "pwd", Value: hex.EncodeToString(psum.Sum(nil))})
+		unset = append(unset, bson.DocElem{Name: "userSource", Value: 1})
 	} else if user.PasswordHash != "" {
-		set = append(set, bson.DocElem{"pwd", user.PasswordHash})
-		unset = append(unset, bson.DocElem{"userSource", 1})
+		set = append(set, bson.DocElem{Name: "pwd", Value: user.PasswordHash})
+		unset = append(unset, bson.DocElem{Name: "userSource", Value: 1})
 	}
 	if user.UserSource != "" {
-		set = append(set, bson.DocElem{"userSource", user.UserSource})
-		unset = append(unset, bson.DocElem{"pwd", 1})
+		set = append(set, bson.DocElem{Name: "userSource", Value: user.UserSource})
+		unset = append(unset, bson.DocElem{Name: "pwd", Value: 1})
 	}
 	if user.Roles != nil || user.OtherDBRoles != nil {
-		set = append(set, bson.DocElem{"roles", user.Roles})
+		set = append(set, bson.DocElem{Name: "roles", Value: user.Roles})
 		if len(user.OtherDBRoles) > 0 {
-			set = append(set, bson.DocElem{"otherDBRoles", user.OtherDBRoles})
+			set = append(set, bson.DocElem{Name: "otherDBRoles", Value: user.OtherDBRoles})
 		} else {
-			unset = append(unset, bson.DocElem{"otherDBRoles", 1})
+			unset = append(unset, bson.DocElem{Name: "otherDBRoles", Value: 1})
 		}
 	}
 	users := db.C("system.users")
-	err = users.Update(bson.D{{"user", user.Username}}, bson.D{{"$unset", unset}, {"$set", set}})
+	err = users.Update(bson.D{{Name: "user", Value: user.Username}}, bson.D{{Name: "$unset", Value: unset}, {Name: "$set", Value: set}})
 	if err == ErrNotFound {
-		set = append(set, bson.DocElem{"user", user.Username})
+		set = append(set, bson.DocElem{Name: "user", Value: user.Username})
 		if user.Roles == nil && user.OtherDBRoles == nil {
 			// Roles must be sent, as it's the way MongoDB distinguishes
 			// old-style documents from new-style documents in pre-2.6.
-			set = append(set, bson.DocElem{"roles", user.Roles})
+			set = append(set, bson.DocElem{Name: "roles", Value: user.Roles})
 		}
 		err = users.Insert(set)
 	}
@@ -1021,9 +1095,9 @@ func isAuthError(err error) bool {
 
 func (db *Database) runUserCmd(cmdName string, user *User) error {
 	cmd := make(bson.D, 0, 16)
-	cmd = append(cmd, bson.DocElem{cmdName, user.Username})
+	cmd = append(cmd, bson.DocElem{Name: cmdName, Value: user.Username})
 	if user.Password != "" {
-		cmd = append(cmd, bson.DocElem{"pwd", user.Password})
+		cmd = append(cmd, bson.DocElem{Name: "pwd", Value: user.Password})
 	}
 	var roles []interface{}
 	for _, role := range user.Roles {
@@ -1031,11 +1105,11 @@ func (db *Database) runUserCmd(cmdName string, user *User) error {
 	}
 	for db, dbroles := range user.OtherDBRoles {
 		for _, role := range dbroles {
-			roles = append(roles, bson.D{{"role", role}, {"db", db}})
+			roles = append(roles, bson.D{{Name: "role", Value: role}, {Name: "db", Value: db}})
 		}
 	}
 	if roles != nil || user.Roles != nil || cmdName == "createUser" {
-		cmd = append(cmd, bson.DocElem{"roles", roles})
+		cmd = append(cmd, bson.DocElem{Name: "roles", Value: roles})
 	}
 	err := db.Run(cmd, nil)
 	if !isNoCmd(err) && user.UserSource != "" && (user.UserSource != "$external" || db.Name != "$external") {
@@ -1084,7 +1158,7 @@ func (db *Database) AddUser(username, password string, readOnly bool) error {
 
 // RemoveUser removes the authentication credentials of user from the database.
 func (db *Database) RemoveUser(user string) error {
-	err := db.Run(bson.D{{"dropUser", user}}, nil)
+	err := db.Run(bson.D{{Name: "dropUser", Value: user}}, nil)
 	if isNoCmd(err) {
 		users := db.C("system.users")
 		return users.Remove(bson.M{"user": user})
@@ -1098,23 +1172,28 @@ func (db *Database) RemoveUser(user string) error {
 type indexSpec struct {
 	Name, NS                string
 	Key                     bson.D
-	Unique                  bool    ",omitempty"
-	DropDups                bool    "dropDups,omitempty"
-	Background              bool    ",omitempty"
-	Sparse                  bool    ",omitempty"
-	Bits                    int     ",omitempty"
-	Min, Max                float64 ",omitempty"
-	BucketSize              float64 "bucketSize,omitempty"
-	ExpireAfter             int     "expireAfterSeconds,omitempty"
-	Weights                 bson.D  ",omitempty"
-	DefaultLanguage         string  "default_language,omitempty"
-	LanguageOverride        string  "language_override,omitempty"
-	TextIndexVersion        int     "textIndexVersion,omitempty"
-	PartialFilterExpression bson.M  "partialFilterExpression,omitempty"
+	Unique                  bool    `bson:",omitempty"`
+	DropDups                bool    `bson:"dropDups,omitempty"`
+	Background              bool    `bson:",omitempty"`
+	Sparse                  bool    `bson:",omitempty"`
+	Bits                    int     `bson:",omitempty"`
+	Min, Max                float64 `bson:",omitempty"`
+	BucketSize              float64 `bson:"bucketSize,omitempty"`
+	ExpireAfter             int     `bson:"expireAfterSeconds,omitempty"`
+	Weights                 bson.D  `bson:",omitempty"`
+	DefaultLanguage         string  `bson:"default_language,omitempty"`
+	LanguageOverride        string  `bson:"language_override,omitempty"`
+	TextIndexVersion        int     `bson:"textIndexVersion,omitempty"`
+	PartialFilterExpression bson.M  `bson:"partialFilterExpression,omitempty"`
 
-	Collation *Collation "collation,omitempty"
+	Collation *Collation `bson:"collation,omitempty"`
 }
 
+// Index are special data structures that store a small portion of the collection’s
+// data set in an easy to traverse form. The index stores the value of a specific
+// field or set of fields, ordered by the value of the field. The ordering of the
+// index entries supports efficient equality matches and range-based query operations.
+// In addition, MongoDB can return sorted results by using the ordering in the index.
 type Index struct {
 	Key           []string // Index key fields; prefix name with dash (-) for descending order
 	Unique        bool     // Prevent two documents from having the same index key
@@ -1157,6 +1236,8 @@ type Index struct {
 	Collation *Collation
 }
 
+// Collation allows users to specify language-specific rules for string comparison,
+// such as rules for lettercase and accent marks.
 type Collation struct {
 
 	// Locale defines the collation locale.
@@ -1271,12 +1352,12 @@ func parseIndexKey(key []string) (*indexKeyInfo, error) {
 		}
 		if kind == "text" {
 			if !isText {
-				keyInfo.key = append(keyInfo.key, bson.DocElem{"_fts", "text"}, bson.DocElem{"_ftsx", 1})
+				keyInfo.key = append(keyInfo.key, bson.DocElem{Name: "_fts", Value: "text"}, bson.DocElem{Name: "_ftsx", Value: 1})
 				isText = true
 			}
-			keyInfo.weights = append(keyInfo.weights, bson.DocElem{field, 1})
+			keyInfo.weights = append(keyInfo.weights, bson.DocElem{Name: field, Value: 1})
 		} else {
-			keyInfo.key = append(keyInfo.key, bson.DocElem{field, order})
+			keyInfo.key = append(keyInfo.key, bson.DocElem{Name: field, Value: order})
 		}
 	}
 	if keyInfo.name == "" {
@@ -1436,7 +1517,7 @@ NextField:
 	db := c.Database.With(cloned)
 
 	// Try with a command first.
-	err = db.Run(bson.D{{"createIndexes", c.Name}, {"indexes", []indexSpec{spec}}}, nil)
+	err = db.Run(bson.D{{Name: "createIndexes", Value: c.Name}, {Name: "indexes", Value: []indexSpec{spec}}}, nil)
 	if isNoCmd(err) {
 		// Command not yet supported. Insert into the indexes collection instead.
 		err = db.C("system.indexes").Insert(&spec)
@@ -1475,7 +1556,7 @@ func (c *Collection) DropIndex(key ...string) error {
 		ErrMsg string
 		Ok     bool
 	}{}
-	err = db.Run(bson.D{{"dropIndexes", c.Name}, {"index", keyInfo.name}}, &result)
+	err = db.Run(bson.D{{Name: "dropIndexes", Value: c.Name}, {Name: "index", Value: keyInfo.name}}, &result)
 	if err != nil {
 		return err
 	}
@@ -1527,7 +1608,7 @@ func (c *Collection) DropIndexName(name string) error {
 		ErrMsg string
 		Ok     bool
 	}{}
-	err = c.Database.Run(bson.D{{"dropIndexes", c.Name}, {"index", name}}, &result)
+	err = c.Database.Run(bson.D{{Name: "dropIndexes", Value: c.Name}, {Name: "index", Value: name}}, &result)
 	if err != nil {
 		return err
 	}
@@ -1550,7 +1631,7 @@ func (c *Collection) DropAllIndexes() error {
 		ErrMsg string
 		Ok     bool
 	}{}
-	err := db.Run(bson.D{{"dropIndexes", c.Name}, {"index", "*"}}, &result)
+	err := db.Run(bson.D{{Name: "dropIndexes", Value: c.Name}, {Name: "index", Value: "*"}}, &result)
 	if err != nil {
 		return err
 	}
@@ -1563,8 +1644,8 @@ func (c *Collection) DropAllIndexes() error {
 // nonEventual returns a clone of session and ensures it is not Eventual.
 // This guarantees that the server that is used for queries may be reused
 // afterwards when a cursor is received.
-func (session *Session) nonEventual() *Session {
-	cloned := session.Clone()
+func (s *Session) nonEventual() *Session {
+	cloned := s.Clone()
 	if cloned.consistency == Eventual {
 		cloned.SetMode(Monotonic, false)
 	}
@@ -1586,7 +1667,7 @@ func (c *Collection) Indexes() (indexes []Index, err error) {
 		Cursor  cursorData
 	}
 	var iter *Iter
-	err = c.Database.With(cloned).Run(bson.D{{"listIndexes", c.Name}, {"cursor", bson.D{{"batchSize", batchSize}}}}, &result)
+	err = c.Database.With(cloned).Run(bson.D{{Name: "listIndexes", Value: c.Name}, {Name: "cursor", Value: bson.D{{Name: "batchSize", Value: batchSize}}}}, &result)
 	if err == nil {
 		firstBatch := result.Indexes
 		if firstBatch == nil {
@@ -1691,7 +1772,7 @@ func simpleIndexKey(realKey bson.D) (key []string) {
 	return
 }
 
-// ResetIndexCache() clears the cache of previously ensured indexes.
+// ResetIndexCache clears the cache of previously ensured indexes.
 // Following requests to EnsureIndex will contact the server.
 func (s *Session) ResetIndexCache() {
 	s.cluster().ResetIndexCache()
@@ -1744,20 +1825,20 @@ func (s *Session) Clone() *Session {
 // after it has been closed.
 func (s *Session) Close() {
 	s.m.Lock()
-	if s.cluster_ != nil {
+	if s.mgoCluster != nil {
 		debugf("Closing session %p", s)
 		s.unsetSocket()
-		s.cluster_.Release()
-		s.cluster_ = nil
+		s.mgoCluster.Release()
+		s.mgoCluster = nil
 	}
 	s.m.Unlock()
 }
 
 func (s *Session) cluster() *mongoCluster {
-	if s.cluster_ == nil {
+	if s.mgoCluster == nil {
 		panic("Session already closed")
 	}
-	return s.cluster_
+	return s.mgoCluster
 }
 
 // Refresh puts back any reserved sockets in use and restarts the consistency
@@ -1942,7 +2023,7 @@ func (s *Session) SetPrefetch(p float64) {
 	s.m.Unlock()
 }
 
-// See SetSafe for details on the Safe type.
+// Safe session safety mode. See SetSafe for details on the Safe type.
 type Safe struct {
 	W        int    // Min # of servers to ack before success
 	WMode    string // Write mode for MongoDB 2.0+ (e.g. "majority")
@@ -2191,7 +2272,7 @@ func (s *Session) Ping() error {
 // is established with. If async is true, the call returns immediately,
 // otherwise it returns after the flush has been made.
 func (s *Session) Fsync(async bool) error {
-	return s.Run(bson.D{{"fsync", 1}, {"async", async}}, nil)
+	return s.Run(bson.D{{Name: "fsync", Value: 1}, {Name: "async", Value: async}}, nil)
 }
 
 // FsyncLock locks all writes in the specific server the session is
@@ -2220,12 +2301,12 @@ func (s *Session) Fsync(async bool) error {
 //     http://www.mongodb.org/display/DOCS/Backups
 //
 func (s *Session) FsyncLock() error {
-	return s.Run(bson.D{{"fsync", 1}, {"lock", true}}, nil)
+	return s.Run(bson.D{{Name: "fsync", Value: 1}, {Name: "lock", Value: true}}, nil)
 }
 
 // FsyncUnlock releases the server for writes. See FsyncLock for details.
 func (s *Session) FsyncUnlock() error {
-	err := s.Run(bson.D{{"fsyncUnlock", 1}}, nil)
+	err := s.Run(bson.D{{Name: "fsyncUnlock", Value: 1}}, nil)
 	if isNoCmd(err) {
 		err = s.DB("admin").C("$cmd.sys.unlock").Find(nil).One(nil) // WTF?
 	}
@@ -2266,7 +2347,7 @@ func (c *Collection) Find(query interface{}) *Query {
 
 type repairCmd struct {
 	RepairCursor string           `bson:"repairCursor"`
-	Cursor       *repairCmdCursor ",omitempty"
+	Cursor       *repairCmdCursor `bson:",omitempty"`
 }
 
 type repairCmdCursor struct {
@@ -2307,9 +2388,11 @@ func (c *Collection) Repair() *Iter {
 //
 // See the Find method for more details.
 func (c *Collection) FindId(id interface{}) *Query {
-	return c.Find(bson.D{{"_id", id}})
+	return c.Find(bson.D{{Name: "_id", Value: id}})
 }
 
+// Pipe is used to run aggregation queries against a
+// collection.
 type Pipe struct {
 	session    *Session
 	collection *Collection
@@ -2321,9 +2404,9 @@ type Pipe struct {
 type pipeCmd struct {
 	Aggregate string
 	Pipeline  interface{}
-	Cursor    *pipeCmdCursor ",omitempty"
-	Explain   bool           ",omitempty"
-	AllowDisk bool           "allowDiskUse,omitempty"
+	Cursor    *pipeCmdCursor `bson:",omitempty"`
+	Explain   bool           `bson:",omitempty"`
+	AllowDisk bool           `bson:"allowDiskUse,omitempty"`
 }
 
 type pipeCmdCursor struct {
@@ -2552,8 +2635,13 @@ func (p *Pipe) Batch(n int) *Pipe {
 	return p
 }
 
+// LastError the error status of the preceding write operation on the current connection.
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/reference/command/getLastError/
+//
 // mgo.v3: Use a single user-visible error type.
-
 type LastError struct {
 	Err             string
 	Code, N, Waited int
@@ -2571,13 +2659,14 @@ func (err *LastError) Error() string {
 }
 
 type queryError struct {
-	Err           string "$err"
+	Err           string `bson:"$err"`
 	ErrMsg        string
 	Assertion     string
 	Code          int
-	AssertionCode int "assertionCode"
+	AssertionCode int `bson:"assertionCode"`
 }
 
+// QueryError is returned when a query fails
 type QueryError struct {
 	Code      int
 	Message   string
@@ -2652,7 +2741,7 @@ func (c *Collection) Update(selector interface{}, update interface{}) error {
 //
 // See the Update method for more details.
 func (c *Collection) UpdateId(id interface{}, update interface{}) error {
-	return c.Update(bson.D{{"_id", id}}, update)
+	return c.Update(bson.D{{Name: "_id", Value: id}}, update)
 }
 
 // ChangeInfo holds details about the outcome of an update operation.
@@ -2747,7 +2836,7 @@ func (c *Collection) Upsert(selector interface{}, update interface{}) (info *Cha
 //
 // See the Upsert method for more details.
 func (c *Collection) UpsertId(id interface{}, update interface{}) (info *ChangeInfo, err error) {
-	return c.Upsert(bson.D{{"_id", id}}, update)
+	return c.Upsert(bson.D{{Name: "_id", Value: id}}, update)
 }
 
 // Remove finds a single document matching the provided selector document
@@ -2777,7 +2866,7 @@ func (c *Collection) Remove(selector interface{}) error {
 //
 // See the Remove method for more details.
 func (c *Collection) RemoveId(id interface{}) error {
-	return c.Remove(bson.D{{"_id", id}})
+	return c.Remove(bson.D{{Name: "_id", Value: id}})
 }
 
 // RemoveAll finds all documents matching the provided selector document
@@ -2802,12 +2891,12 @@ func (c *Collection) RemoveAll(selector interface{}) (info *ChangeInfo, err erro
 
 // DropDatabase removes the entire database including all of its collections.
 func (db *Database) DropDatabase() error {
-	return db.Run(bson.D{{"dropDatabase", 1}}, nil)
+	return db.Run(bson.D{{Name: "dropDatabase", Value: 1}}, nil)
 }
 
 // DropCollection removes the entire collection including all of its documents.
 func (c *Collection) DropCollection() error {
-	return c.Database.Run(bson.D{{"drop", c.Name}}, nil)
+	return c.Database.Run(bson.D{{Name: "drop", Value: c.Name}}, nil)
 }
 
 // The CollectionInfo type holds metadata about a collection.
@@ -2875,37 +2964,37 @@ type CollectionInfo struct {
 //
 func (c *Collection) Create(info *CollectionInfo) error {
 	cmd := make(bson.D, 0, 4)
-	cmd = append(cmd, bson.DocElem{"create", c.Name})
+	cmd = append(cmd, bson.DocElem{Name: "create", Value: c.Name})
 	if info.Capped {
 		if info.MaxBytes < 1 {
 			return fmt.Errorf("Collection.Create: with Capped, MaxBytes must also be set")
 		}
-		cmd = append(cmd, bson.DocElem{"capped", true})
-		cmd = append(cmd, bson.DocElem{"size", info.MaxBytes})
+		cmd = append(cmd, bson.DocElem{Name: "capped", Value: true})
+		cmd = append(cmd, bson.DocElem{Name: "size", Value: info.MaxBytes})
 		if info.MaxDocs > 0 {
-			cmd = append(cmd, bson.DocElem{"max", info.MaxDocs})
+			cmd = append(cmd, bson.DocElem{Name: "max", Value: info.MaxDocs})
 		}
 	}
 	if info.DisableIdIndex {
-		cmd = append(cmd, bson.DocElem{"autoIndexId", false})
+		cmd = append(cmd, bson.DocElem{Name: "autoIndexId", Value: false})
 	}
 	if info.ForceIdIndex {
-		cmd = append(cmd, bson.DocElem{"autoIndexId", true})
+		cmd = append(cmd, bson.DocElem{Name: "autoIndexId", Value: true})
 	}
 	if info.Validator != nil {
-		cmd = append(cmd, bson.DocElem{"validator", info.Validator})
+		cmd = append(cmd, bson.DocElem{Name: "validator", Value: info.Validator})
 	}
 	if info.ValidationLevel != "" {
-		cmd = append(cmd, bson.DocElem{"validationLevel", info.ValidationLevel})
+		cmd = append(cmd, bson.DocElem{Name: "validationLevel", Value: info.ValidationLevel})
 	}
 	if info.ValidationAction != "" {
-		cmd = append(cmd, bson.DocElem{"validationAction", info.ValidationAction})
+		cmd = append(cmd, bson.DocElem{Name: "validationAction", Value: info.ValidationAction})
 	}
 	if info.StorageEngine != nil {
-		cmd = append(cmd, bson.DocElem{"storageEngine", info.StorageEngine})
+		cmd = append(cmd, bson.DocElem{Name: "storageEngine", Value: info.StorageEngine})
 	}
 	if info.Collation != nil {
-		cmd = append(cmd, bson.DocElem{"collation", info.Collation})
+		cmd = append(cmd, bson.DocElem{Name: "collation", Value: info.Collation})
 	}
 
 	return c.Database.Run(cmd, nil)
@@ -2914,7 +3003,7 @@ func (c *Collection) Create(info *CollectionInfo) error {
 // Batch sets the batch size used when fetching documents from the database.
 // It's possible to change this setting on a per-session basis as well, using
 // the Batch method of Session.
-
+//
 // The default batch size is defined by the database itself.  As of this
 // writing, MongoDB will use an initial size of min(100 docs, 4MB) on the
 // first batch, and 4MB on remaining ones.
@@ -3036,9 +3125,9 @@ func (q *Query) Sort(fields ...string) *Query {
 			panic("Sort: empty field name")
 		}
 		if kind == "textScore" {
-			order = append(order, bson.DocElem{field, bson.M{"$meta": kind}})
+			order = append(order, bson.DocElem{Name: field, Value: bson.M{"$meta": kind}})
 		} else {
-			order = append(order, bson.DocElem{field, n})
+			order = append(order, bson.DocElem{Name: field, Value: n})
 		}
 	}
 	q.op.options.OrderBy = order
@@ -3406,15 +3495,15 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	op.hasOptions = false
 
 	if explain {
-		op.query = bson.D{{"explain", op.query}}
+		op.query = bson.D{{Name: "explain", Value: op.query}}
 		return false
 	}
 	return true
 }
 
 type cursorData struct {
-	FirstBatch []bson.Raw "firstBatch"
-	NextBatch  []bson.Raw "nextBatch"
+	FirstBatch []bson.Raw `bson:"firstBatch"`
+	NextBatch  []bson.Raw `bson:"nextBatch"`
 	NS         string
 	Id         int64
 }
@@ -3477,7 +3566,7 @@ type getMoreCmd struct {
 func (db *Database) run(socket *mongoSocket, cmd, result interface{}) (err error) {
 	// Database.Run:
 	if name, ok := cmd.(string); ok {
-		cmd = bson.D{{name, 1}}
+		cmd = bson.D{{Name: name, Value: 1}}
 	}
 
 	// Collection.Find:
@@ -3566,7 +3655,7 @@ func (db *Database) FindRef(ref *DBRef) *Query {
 //
 func (s *Session) FindRef(ref *DBRef) *Query {
 	if ref.Database == "" {
-		panic(errors.New(fmt.Sprintf("Can't resolve database for %#v", ref)))
+		panic(fmt.Errorf("Can't resolve database for %#v", ref))
 	}
 	c := s.DB(ref.Database).C(ref.Collection)
 	return c.FindId(ref.Id)
@@ -3587,7 +3676,7 @@ func (db *Database) CollectionNames() (names []string, err error) {
 		Collections []bson.Raw
 		Cursor      cursorData
 	}
-	err = db.With(cloned).Run(bson.D{{"listCollections", 1}, {"cursor", bson.D{{"batchSize", batchSize}}}}, &result)
+	err = db.With(cloned).Run(bson.D{{Name: "listCollections", Value: 1}, {Name: "cursor", Value: bson.D{{Name: "batchSize", Value: batchSize}}}}, &result)
 	if err == nil {
 		firstBatch := result.Collections
 		if firstBatch == nil {
@@ -4052,13 +4141,13 @@ func (q *Query) All(result interface{}) error {
 	return q.Iter().All(result)
 }
 
-// The For method is obsolete and will be removed in a future release.
+// For method is obsolete and will be removed in a future release.
 // See Iter as an elegant replacement.
 func (q *Query) For(result interface{}, f func() error) error {
 	return q.Iter().For(result, f)
 }
 
-// The For method is obsolete and will be removed in a future release.
+// For method is obsolete and will be removed in a future release.
 // See Iter as an elegant replacement.
 func (iter *Iter) For(result interface{}, f func() error) (err error) {
 	valid := false
@@ -4177,8 +4266,8 @@ func (iter *Iter) getMoreCmd() *queryOp {
 type countCmd struct {
 	Count     string
 	Query     interface{}
-	Limit     int32  ",omitempty"
-	Skip      int32  ",omitempty"
+	Limit     int32  `bson:",omitempty"`
+	Skip      int32  `bson:",omitempty"`
 	Hint      bson.D `bson:"hint,omitempty"`
 	MaxTimeMS int    `bson:"maxTimeMS,omitempty"`
 }
@@ -4217,9 +4306,9 @@ func (c *Collection) Count() (n int, err error) {
 }
 
 type distinctCmd struct {
-	Collection string "distinct"
+	Collection string `bson:"distinct"`
 	Key        string
-	Query      interface{} ",omitempty"
+	Query      interface{} `bson:",omitempty"`
 }
 
 // Distinct unmarshals into result the list of distinct values for the given key.
@@ -4256,28 +4345,34 @@ func (q *Query) Distinct(key string, result interface{}) error {
 }
 
 type mapReduceCmd struct {
-	Collection string "mapreduce"
-	Map        string ",omitempty"
-	Reduce     string ",omitempty"
-	Finalize   string ",omitempty"
+	Collection string `bson:"mapreduce"`
+	Map        string `bson:",omitempty"`
+	Reduce     string `bson:",omitempty"`
+	Finalize   string `bson:",omitempty"`
 	Out        interface{}
-	Query      interface{} ",omitempty"
-	Sort       interface{} ",omitempty"
-	Scope      interface{} ",omitempty"
-	Limit      int32       ",omitempty"
-	Verbose    bool        ",omitempty"
+	Query      interface{} `bson:",omitempty"`
+	Sort       interface{} `bson:",omitempty"`
+	Scope      interface{} `bson:",omitempty"`
+	Limit      int32       `bson:",omitempty"`
+	Verbose    bool        `bson:",omitempty"`
 }
 
 type mapReduceResult struct {
 	Results    bson.Raw
 	Result     bson.Raw
-	TimeMillis int64 "timeMillis"
+	TimeMillis int64 `bson:"timeMillis"`
 	Counts     struct{ Input, Emit, Output int }
 	Ok         bool
 	Err        string
 	Timing     *MapReduceTime
 }
 
+// MapReduce used to perform Map Reduce operations
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/core/map-reduce/
+//
 type MapReduce struct {
 	Map      string      // Map Javascript function code (required)
 	Reduce   string      // Reduce Javascript function code (required)
@@ -4287,6 +4382,7 @@ type MapReduce struct {
 	Verbose  bool
 }
 
+// MapReduceInfo stores informations on a MapReduce operation
 type MapReduceInfo struct {
 	InputCount  int            // Number of documents mapped
 	EmitCount   int            // Number of times reduce called emit
@@ -4297,10 +4393,11 @@ type MapReduceInfo struct {
 	VerboseTime *MapReduceTime // Only defined if Verbose was true
 }
 
+// MapReduceTime stores execution time of a MapReduce operation
 type MapReduceTime struct {
 	Total    int64 // Total time, in nanoseconds
-	Map      int64 "mapTime"  // Time within map function, in nanoseconds
-	EmitLoop int64 "emitLoop" // Time within the emit/map loop, in nanoseconds
+	Map      int64 `bson:"mapTime"`  // Time within map function, in nanoseconds
+	EmitLoop int64 `bson:"emitLoop"` // Time within the emit/map loop, in nanoseconds
 }
 
 // MapReduce executes a map/reduce job for documents covered by the query.
@@ -4391,7 +4488,7 @@ func (q *Query) MapReduce(job *MapReduce, result interface{}) (info *MapReduceIn
 	}
 
 	if cmd.Out == nil {
-		cmd.Out = bson.D{{"inline", 1}}
+		cmd.Out = bson.D{{Name: "inline", Value: 1}}
 	}
 
 	var doc mapReduceResult
@@ -4476,14 +4573,14 @@ type Change struct {
 }
 
 type findModifyCmd struct {
-	Collection                  string      "findAndModify"
-	Query, Update, Sort, Fields interface{} ",omitempty"
-	Upsert, Remove, New         bool        ",omitempty"
+	Collection                  string      `bson:"findAndModify"`
+	Query, Update, Sort, Fields interface{} `bson:",omitempty"`
+	Upsert, Remove, New         bool        `bson:",omitempty"`
 }
 
 type valueResult struct {
 	Value     bson.Raw
-	LastError LastError "lastErrorObject"
+	LastError LastError `bson:"lastErrorObject"`
 }
 
 // Apply runs the findAndModify MongoDB command, which allows updating, upserting
@@ -4615,7 +4712,7 @@ func (bi *BuildInfo) VersionAtLeast(version ...int) bool {
 // BuildInfo retrieves the version and other details about the
 // running MongoDB server.
 func (s *Session) BuildInfo() (info BuildInfo, err error) {
-	err = s.Run(bson.D{{"buildInfo", "1"}}, &info)
+	err = s.Run(bson.D{{Name: "buildInfo", Value: "1"}}, &info)
 	if len(info.VersionArray) == 0 {
 		for _, a := range strings.Split(info.Version, ".") {
 			i, err := strconv.Atoi(a)
@@ -4809,7 +4906,7 @@ type writeCmdResult struct {
 	NModified int `bson:"nModified"`
 	Upserted  []struct {
 		Index int
-		Id    interface{} `_id`
+		Id    interface{} `bson:"_id"`
 	}
 	ConcernError writeConcernError `bson:"writeConcernError"`
 	Errors       []writeCmdError   `bson:"writeErrors"`
@@ -5022,7 +5119,7 @@ func (c *Collection) writeOpQuery(socket *mongoSocket, safeOp *queryOp, op inter
 func (c *Collection) writeOpCommand(socket *mongoSocket, safeOp *queryOp, op interface{}, ordered, bypassValidation bool) (lerr *LastError, err error) {
 	var writeConcern interface{}
 	if safeOp == nil {
-		writeConcern = bson.D{{"w", 0}}
+		writeConcern = bson.D{{Name: "w", Value: 0}}
 	} else {
 		writeConcern = safeOp.query.(*getLastError)
 	}
@@ -5032,46 +5129,46 @@ func (c *Collection) writeOpCommand(socket *mongoSocket, safeOp *queryOp, op int
 	case *insertOp:
 		// http://docs.mongodb.org/manual/reference/command/insert
 		cmd = bson.D{
-			{"insert", c.Name},
-			{"documents", op.documents},
-			{"writeConcern", writeConcern},
-			{"ordered", op.flags&1 == 0},
+			{Name: "insert", Value: c.Name},
+			{Name: "documents", Value: op.documents},
+			{Name: "writeConcern", Value: writeConcern},
+			{Name: "ordered", Value: op.flags&1 == 0},
 		}
 	case *updateOp:
 		// http://docs.mongodb.org/manual/reference/command/update
 		cmd = bson.D{
-			{"update", c.Name},
-			{"updates", []interface{}{op}},
-			{"writeConcern", writeConcern},
-			{"ordered", ordered},
+			{Name: "update", Value: c.Name},
+			{Name: "updates", Value: []interface{}{op}},
+			{Name: "writeConcern", Value: writeConcern},
+			{Name: "ordered", Value: ordered},
 		}
 	case bulkUpdateOp:
 		// http://docs.mongodb.org/manual/reference/command/update
 		cmd = bson.D{
-			{"update", c.Name},
-			{"updates", op},
-			{"writeConcern", writeConcern},
-			{"ordered", ordered},
+			{Name: "update", Value: c.Name},
+			{Name: "updates", Value: op},
+			{Name: "writeConcern", Value: writeConcern},
+			{Name: "ordered", Value: ordered},
 		}
 	case *deleteOp:
 		// http://docs.mongodb.org/manual/reference/command/delete
 		cmd = bson.D{
-			{"delete", c.Name},
-			{"deletes", []interface{}{op}},
-			{"writeConcern", writeConcern},
-			{"ordered", ordered},
+			{Name: "delete", Value: c.Name},
+			{Name: "deletes", Value: []interface{}{op}},
+			{Name: "writeConcern", Value: writeConcern},
+			{Name: "ordered", Value: ordered},
 		}
 	case bulkDeleteOp:
 		// http://docs.mongodb.org/manual/reference/command/delete
 		cmd = bson.D{
-			{"delete", c.Name},
-			{"deletes", op},
-			{"writeConcern", writeConcern},
-			{"ordered", ordered},
+			{Name: "delete", Value: c.Name},
+			{Name: "deletes", Value: op},
+			{Name: "writeConcern", Value: writeConcern},
+			{Name: "ordered", Value: ordered},
 		}
 	}
 	if bypassValidation {
-		cmd = append(cmd, bson.DocElem{"bypassDocumentValidation", true})
+		cmd = append(cmd, bson.DocElem{Name: "bypassDocumentValidation", Value: true})
 	}
 
 	var result writeCmdResult

--- a/socket.go
+++ b/socket.go
@@ -83,16 +83,16 @@ type queryOp struct {
 }
 
 type queryWrapper struct {
-	Query          interface{} "$query"
-	OrderBy        interface{} "$orderby,omitempty"
-	Hint           interface{} "$hint,omitempty"
-	Explain        bool        "$explain,omitempty"
-	Snapshot       bool        "$snapshot,omitempty"
-	ReadPreference bson.D      "$readPreference,omitempty"
-	MaxScan        int         "$maxScan,omitempty"
-	MaxTimeMS      int         "$maxTimeMS,omitempty"
-	Comment        string      "$comment,omitempty"
-	Collation      *Collation  "$collation,omitempty"
+	Query          interface{} `bson:"$query"`
+	OrderBy        interface{} `bson:"$orderby,omitempty"`
+	Hint           interface{} `bson:"$hint,omitempty"`
+	Explain        bool        `bson:"$explain,omitempty"`
+	Snapshot       bool        `bson:"$snapshot,omitempty"`
+	ReadPreference bson.D      `bson:"$readPreference,omitempty"`
+	MaxScan        int         `bson:"$maxScan,omitempty"`
+	MaxTimeMS      int         `bson:"$maxTimeMS,omitempty"`
+	Comment        string      `bson:"$comment,omitempty"`
+	Collation      *Collation  `bson:"$collation,omitempty"`
 }
 
 func (op *queryOp) finalQuery(socket *mongoSocket) interface{} {
@@ -116,9 +116,9 @@ func (op *queryOp) finalQuery(socket *mongoSocket) interface{} {
 		}
 		op.hasOptions = true
 		op.options.ReadPreference = make(bson.D, 0, 2)
-		op.options.ReadPreference = append(op.options.ReadPreference, bson.DocElem{"mode", modeName})
+		op.options.ReadPreference = append(op.options.ReadPreference, bson.DocElem{Name: "mode", Value: modeName})
 		if len(op.serverTags) > 0 {
-			op.options.ReadPreference = append(op.options.ReadPreference, bson.DocElem{"tags", op.serverTags})
+			op.options.ReadPreference = append(op.options.ReadPreference, bson.DocElem{Name: "tags", Value: op.serverTags})
 		}
 	}
 	if op.hasOptions {

--- a/stats.go
+++ b/stats.go
@@ -33,6 +33,7 @@ import (
 var stats *Stats
 var statsMutex sync.Mutex
 
+// SetStats enable database state monitoring
 func SetStats(enabled bool) {
 	statsMutex.Lock()
 	if enabled {
@@ -45,6 +46,7 @@ func SetStats(enabled bool) {
 	statsMutex.Unlock()
 }
 
+// GetStats return the current database state
 func GetStats() (snapshot Stats) {
 	statsMutex.Lock()
 	snapshot = *stats
@@ -52,6 +54,7 @@ func GetStats() (snapshot Stats) {
 	return
 }
 
+// ResetStats reset Stats to the previous database state
 func ResetStats() {
 	statsMutex.Lock()
 	debug("Resetting stats")
@@ -66,6 +69,13 @@ func ResetStats() {
 	return
 }
 
+// Stats holds info on the database state
+//
+// Relevant documentation:
+//
+//    https://docs.mongodb.com/manual/reference/command/serverStatus/
+//
+// TODO outdated fields ?
 type Stats struct {
 	Clusters     int
 	MasterConns  int

--- a/txn/debug.go
+++ b/txn/debug.go
@@ -11,15 +11,15 @@ import (
 
 var (
 	debugEnabled bool
-	logger       log_Logger
+	logger       logLogger
 )
 
-type log_Logger interface {
+type logLogger interface {
 	Output(calldepth int, s string) error
 }
 
-// Specify the *log.Logger where logged messages should be sent to.
-func SetLogger(l log_Logger) {
+// SetLogger specify the *log.Logger where logged messages should be sent to.
+func SetLogger(l logLogger) {
 	logger = l
 }
 
@@ -28,6 +28,8 @@ func SetDebug(debug bool) {
 	debugEnabled = debug
 }
 
+// ErrChaos error returned when operation failed due to
+// the failure injection mechanism.
 var ErrChaos = fmt.Errorf("interrupted by chaos")
 
 var debugId uint32


### PR DESCRIPTION
**WIP - Do not merge**
 
This PR is an attempt to fix `golint`, `go vet` and `gofmt` warning of all files in the project ( see #43 for details) 

A few warnings are still raised by `go vet`: 

```
session.go:661: assignment copies lock value to scopy: mgo.Session contains sync.RWMutex
```
   -> not sure how to handle this one 

```
internal/json/decode_test.go:1350: struct field m has json tag but is not exported
internal/json/decode_test.go:1351: struct field m2 has json tag but is not exported
internal/json/tagkey_test.go:56: struct field tag `:"BadFormat"` not compatible with reflect.StructTag.Get: bad syntax for struct tag key
```
  -> part of the tests and intended to be badly formatted. 

I was able to fix all golint warnings, but bad news is that it currently breaks backward compatibility...
`golint` raise warnings about `Id` not being `ID`, and theres many occurence of this in mgo (`ObjectId`, `FindId()` ...) 

This might be fixed with type alias to preserve backward compatibility ? 

Waiting for any feedback on this, 

Feliixx