### PR TITLE
Introduce `bson.OmitEmptyAware` for custom marshaled structs

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -130,7 +130,8 @@ type Setter interface {
 	SetBSON(raw Raw) error
 }
 
-// Implement this interface to enable struct type to be omitted by `omitempty`.
+// OmitEmptyAware allows you to control when a field of this type should be
+// serialized in the presence of an annotation `omitempty`.
 type OmitEmptyAware interface {
 	ShouldOmitAsEmpty() bool
 }
@@ -188,6 +189,7 @@ type Raw struct {
 	Data []byte
 }
 
+// ShouldOmitAsEmpty omit empty Raw field serialization.
 func (raw Raw) ShouldOmitAsEmpty() bool {
 	return raw.Kind == 0 && len(raw.Data) == 0
 }

--- a/bson/bson.go
+++ b/bson/bson.go
@@ -130,6 +130,11 @@ type Setter interface {
 	SetBSON(raw Raw) error
 }
 
+// Implement this interface to enable struct type to be omitted by `omitempty`.
+type OmitEmptyAware interface {
+	ShouldOmitAsEmpty() bool
+}
+
 // ErrSetZero may be returned from a SetBSON method to have the value set to
 // its respective zero value. When used in pointer values, this will set the
 // field to nil rather than to the pre-allocated value.
@@ -181,6 +186,10 @@ func (d D) Map() (m M) {
 type Raw struct {
 	Kind byte
 	Data []byte
+}
+
+func (raw Raw) ShouldOmitAsEmpty() bool {
+	return raw.Kind == 0 && len(raw.Data) == 0
 }
 
 // RawD represents a BSON document containing raw unprocessed elements.

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -1179,6 +1179,19 @@ func (s ifaceSlice) GetBSON() (interface{}, error) {
 	return []int{len(s)}, nil
 }
 
+type omitEmptyAware struct {
+	empty bool
+	A     int
+}
+
+func (e omitEmptyAware) ShouldOmitAsEmpty() bool {
+	return e.empty
+}
+
+type condAware struct {
+	V omitEmptyAware `bson:",omitempty"`
+}
+
 type (
 	MyString string
 	MyBytes  []byte
@@ -1438,6 +1451,14 @@ var oneWayCrossItems = []crossTypeItem{
 
 	// Attempt to marshal slice into RawD (issue #120).
 	{bson.M{"x": []int{1, 2, 3}}, &struct{ X bson.RawD }{}},
+
+	{&condStruct{struct{ A []int }{}}, bson.M{}},
+	{bson.M{"v": bson.M{"a": []interface{}{}}}, &condStruct{struct{ A []int }{[]int{}}}},
+
+	{condAware{omitEmptyAware{true, 0}}, bson.M{}},
+	{condAware{omitEmptyAware{false, 0}}, bson.M{"v": bson.M{"a": 0}}},
+	{condAware{omitEmptyAware{true, 1}}, bson.M{}},
+	{condAware{omitEmptyAware{false, 1}}, bson.M{"v": bson.M{"a": 1}}},
 }
 
 func testCrossPair(c *C, dump interface{}, load interface{}) {

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -251,6 +251,11 @@ func isZero(v reflect.Value) bool {
 		if vt == typeTime {
 			return v.Interface().(time.Time).IsZero()
 		}
+		if v.CanInterface() {
+			if omitEmptyAware, ok := v.Interface().(OmitEmptyAware); ok {
+				return omitEmptyAware.ShouldOmitAsEmpty()
+			}
+		}
 		for i := 0; i < v.NumField(); i++ {
 			if vt.Field(i).PkgPath != "" && !vt.Field(i).Anonymous {
 				continue // Private field


### PR DESCRIPTION
This change allow control `omitempty` behavior for custom marshaling types.
In current code custom marshaling structs can't store serializable data in private files without false positive on `omitempty` fields.