### PR TITLE
Do not lock while writing to a socket

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -549,16 +549,15 @@ func (socket *mongoSocket) Query(ops ...interface{}) (err error) {
 		socket.replyFuncs[requestId] = request.replyFunc
 		requestId++
 	}
-
+	socket.Unlock()
 	debugf("Socket %p to %s: sending %d op(s) (%d bytes)", socket, socket.addr, len(ops), len(buf))
-	stats.sentOps(len(ops))
 
+	stats.sentOps(len(ops))
 	socket.updateDeadline(writeDeadline)
 	_, err = socket.conn.Write(buf)
 	if !wasWaiting && requestCount > 0 {
 		socket.updateDeadline(readDeadline)
 	}
-	socket.Unlock()
 	return err
 }
 


### PR DESCRIPTION
A `net.Conn` is defined as being safe for concurrent access ([here](https://golang.org/pkg/net/#Conn)) however mgo holds the socket lock for the duration of a write unnecessarily.