### PR TITLE
Early socket lock release in Query (retarget #52)

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -549,16 +549,15 @@ func (socket *mongoSocket) Query(ops ...interface{}) (err error) {
 		socket.replyFuncs[requestId] = request.replyFunc
 		requestId++
 	}
-
+	socket.Unlock()
 	debugf("Socket %p to %s: sending %d op(s) (%d bytes)", socket, socket.addr, len(ops), len(buf))
-	stats.sentOps(len(ops))
 
+	stats.sentOps(len(ops))
 	socket.updateDeadline(writeDeadline)
 	_, err = socket.conn.Write(buf)
 	if !wasWaiting && requestCount > 0 {
 		socket.updateDeadline(readDeadline)
 	}
-	socket.Unlock()
 	return err
 }
 


### PR DESCRIPTION
See #52.

Reverted merge as it incorrectly targeted `master` and I didn't notice. For future reference @idy please read the [contribution guidelines](https://github.com/globalsign/mgo/blob/development/CONTRIBUTING.md).