### PR TITLE
Handle OP_MSG requests exceeding MaxMessageSizeBytes

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -34,9 +34,9 @@ import (
 	"errors"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 
 	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -524,3 +524,22 @@ func (s *S) TestBulkRemoveAll(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res, DeepEquals, []doc{{3}})
 }
+
+func (s *S) TestBulkInsertMaxMessageSize(c *C) {
+	session, err := mgo.Dial("localhost:40001" + expFeaturesString)
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	coll := session.DB("mydb").C("mycoll")
+	defer coll.DropCollection()
+
+	bulk := coll.Bulk()
+	bulk.Unordered()
+	binaryData := make([]byte, 600)
+
+	for i := 0; i < 100000; i++ {
+		bulk.Insert(M{"binaryData": binaryData})
+	}
+	_, err = bulk.Run()
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
**WIP - do not merge**

This PR tries to fix #67. All tests are passing but there's still room for a lot of improvements, especially regarding performances. I'll try to optimize this later 

**before this commit:**

```
goos: linux
goarch: amd64
BenchmarkBulkInsert-2        	     200	   6666757 ns/op	  594034 B/op	    7960 allocs/op
BenchmarkBulkInsertOpMsg-2   	     200	   6178964 ns/op	  554147 B/op	    7053 allocs/op
```
**After this commit:**

```
goos: linux
goarch: amd64
BenchmarkBulkInsert-2        	     200	   6552978 ns/op	  663142 B/op	    8961 allocs/op
BenchmarkBulkInsertOpMsg-2   	     200	   6405799 ns/op	  684696 B/op	    8066 allocs/op
```
using this code for benchmarking: 

```
	s, err := mgo.Dial("mongodb://localhost:27017")
	if err != nil {
		b.Fail()
	}
	c := s.DB("bench").C("test")
	b.ResetTimer()

	for n := 0; n < b.N; n++ {
		bulk := c.Bulk()
		bulk.Unordered()
		for i := 0; i < 1000; i++ {
			bulk.Insert(bson.M{"n": i})
		}
		_, err := bulk.Run()
		if err != nil {
			b.Fail()
		}
	}
```

Any comments / review on this is welcome! 