### PR TITLE
Brings in a patch on having flusher not suppress errors.

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -759,7 +759,7 @@ func (f *flusher) checkpoint(t *transaction, revnos []int64) error {
 		f.debugf("Ready to apply %s. Saving revnos %v: LOST RACE", t, debugRevnos)
 		return f.reload(t)
 	}
-	return nil
+	return err
 }
 
 func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) error {


### PR DESCRIPTION
This brings forward a patch that we created for mgo a while ago.
It is possible that if the connection dies in the middle of flushing a transaction, you can get into an endless loop. This causes it to fail with an error instead.

Original PR was here: https://github.com/go-mgo/mgo/pull/360
