### PR TITLE
remove client metadata completely to fix reconnection issues (WIP)

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -157,7 +157,7 @@ func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResul
 	if cluster.appName != "" {
 		metaInfo["application"] = bson.M{"name": cluster.appName}
 	}
-	err := session.Run(bson.D{{Name: "isMaster", Value: 1}, {Name: "client", Value: metaInfo}}, result)
+	err := session.Run(bson.D{{Name: "isMaster", Value: 1}}, result)
 	session.Close()
 	return err
 }


### PR DESCRIPTION
This PR is only opened to point out how the problem mentioned in #101 and #103 can be mitigated. This doesn't suggest an actual solution to the problem, where we keep sending the metadata for the first sync request. 