### PR TITLE
bson: Added Encoder and Decoder types for stream encoding/decoding.

### DIFF
--- a/bson/stream.go
+++ b/bson/stream.go
@@ -12,8 +12,8 @@ type Decoder struct {
 
 // NewDecoder returns a new Decoder that reads from source.
 // It does not add any extra buffering, and may not read data from source beyond the BSON values requested.
-func NewDecoder(source io.Reader) Decoder {
-	return Decoder{source: source}
+func NewDecoder(source io.Reader) *Decoder {
+	return &Decoder{source: source}
 }
 
 // Decode reads the next BSON-encoded value from its input and stores it in the value pointed to by v.
@@ -46,8 +46,8 @@ type Encoder struct {
 }
 
 // NewEncoder returns a new Encoder that writes to target.
-func NewEncoder(target io.Writer) Encoder {
-	return Encoder{target: target}
+func NewEncoder(target io.Writer) *Encoder {
+	return &Encoder{target: target}
 }
 
 // Encode encodes v to BSON, and if successful writes it to the Encoder's output stream.

--- a/bson/stream.go
+++ b/bson/stream.go
@@ -1,0 +1,63 @@
+package bson
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// A Decoder reads and decodes BSON values from an input stream.
+type Decoder struct {
+	source io.Reader
+}
+
+// NewDecoder returns a new Decoder that reads from source.
+// It does not add any extra buffering, and may not read data from source beyond the BSON values requested.
+func NewDecoder(source io.Reader) Decoder {
+	return Decoder{source: source}
+}
+
+// Decode reads the next BSON-encoded value from its input and stores it in the value pointed to by v.
+// See the documentation for Unmarshal for details about the conversion of BSON into a Go value.
+func (dec *Decoder) Decode(v interface{}) error {
+	// BSON documents start with their size as a uint32.
+	document := make([]byte, 4)
+
+	if _, err := io.ReadFull(dec.source, document); err != nil {
+		return err
+	}
+
+	docSize := int(binary.LittleEndian.Uint32(document))
+
+	// Read the rest of the BSON document.
+	tailSize := docSize - 4
+	tail := make([]byte, tailSize)
+	if _, err := io.ReadFull(dec.source, tail); err != nil {
+		return err
+	}
+	document = append(document, tail...)
+
+	// Let Unmarshal handle the rest.
+	return Unmarshal(document, v)
+}
+
+// An Encoder encodes and writes BSON values to an output stream.
+type Encoder struct {
+	target io.Writer
+}
+
+// NewEncoder returns a new Encoder that writes to target.
+func NewEncoder(target io.Writer) Encoder {
+	return Encoder{target: target}
+}
+
+// Encode encodes v to BSON, and if successful writes it to the Encoder's output stream.
+// See the documentation for Marshal for details about the conversion of Go values to BSON.
+func (enc *Encoder) Encode(v interface{}) error {
+	data, err := Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	_, err = enc.target.Write(data)
+	return err
+}

--- a/bson/stream.go
+++ b/bson/stream.go
@@ -8,15 +8,17 @@ import (
 )
 
 const (
-	// Minimal BSON document: int32 (size) + 0x00 (end of document)
-	minDocumentSize = 5
-	// Max size = 16 MiB
-	// (see https://docs.mongodb.com/manual/reference/limits/)
-	maxDocumentSize = 16777216
+	// MinDocumentSize is the size of the smallest possible valid BSON document:
+	// an int32 size header + 0x00 (end of document).
+	MinDocumentSize = 5
+
+	// MaxDocumentSize is the largest possible size for a BSON document allowed by MongoDB,
+	// that is, 16 MiB (see https://docs.mongodb.com/manual/reference/limits/).
+	MaxDocumentSize = 16777216
 )
 
 // ErrInvalidDocumentSize is an error returned when a BSON document's header
-// contains a size smaller than minDocumentSize or greater than maxDocumentSize.
+// contains a size smaller than MinDocumentSize or greater than MaxDocumentSize.
 type ErrInvalidDocumentSize struct {
 	DocumentSize int32
 }
@@ -45,7 +47,7 @@ func (dec *Decoder) Decode(v interface{}) (err error) {
 		return
 	}
 
-	if docSize < minDocumentSize || docSize > maxDocumentSize {
+	if docSize < MinDocumentSize || docSize > MaxDocumentSize {
 		return ErrInvalidDocumentSize{DocumentSize: docSize}
 	}
 

--- a/bson/stream_test.go
+++ b/bson/stream_test.go
@@ -1,0 +1,52 @@
+package bson_test
+
+import (
+	"bytes"
+
+	"github.com/globalsign/mgo/bson"
+	. "gopkg.in/check.v1"
+)
+
+// Reusing sampleItems from bson_test
+
+func (s *S) TestEncodeSampleItems(c *C) {
+	for i, item := range sampleItems {
+		buf := bytes.NewBuffer(nil)
+		enc := bson.NewEncoder(buf)
+
+		err := enc.Encode(item.obj)
+		c.Assert(err, IsNil)
+		c.Assert(string(buf.Bytes()), Equals, item.data, Commentf("Failed on item %d", i))
+	}
+}
+
+func (s *S) TestDecodeSampleItems(c *C) {
+	for i, item := range sampleItems {
+		buf := bytes.NewBuffer([]byte(item.data))
+		dec := bson.NewDecoder(buf)
+
+		value := bson.M{}
+		err := dec.Decode(&value)
+		c.Assert(err, IsNil)
+		c.Assert(value, DeepEquals, item.obj, Commentf("Failed on item %d", i))
+	}
+}
+
+func (s *S) TestStreamRoundTrip(c *C) {
+	buf := bytes.NewBuffer(nil)
+	enc := bson.NewEncoder(buf)
+
+	for _, item := range sampleItems {
+		err := enc.Encode(item.obj)
+		c.Assert(err, IsNil)
+	}
+
+	// Ensure that everything that was encoded is decodable in the same order.
+	dec := bson.NewDecoder(buf)
+	for i, item := range sampleItems {
+		value := bson.M{}
+		err := dec.Decode(&value)
+		c.Assert(err, IsNil)
+		c.Assert(value, DeepEquals, item.obj, Commentf("Failed on item %d", i))
+	}
+}


### PR DESCRIPTION
Those types are analog to those found in json and yaml. They allow us to operate on io.Readers/io.Writers instead of raw byte slices. Streams are expected to be sequences of concatenated BSON documents: *.bson files from MongoDB dumps, for example.