### PR TITLE
Add switch for ignoring `omitempty`

### DIFF
--- a/bson/config.go
+++ b/bson/config.go
@@ -1,0 +1,11 @@
+package bson
+
+var ignoreOmitempty = false
+
+func SetIgnoreOmitempty(state bool) {
+	ignoreOmitempty = state
+}
+
+func IgnoreOmitemptyState() bool {
+	return ignoreOmitempty
+}

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -222,7 +222,7 @@ func (e *encoder) addStruct(v reflect.Value) {
 		} else {
 			value = v.FieldByIndex(info.Inline)
 		}
-		if info.OmitEmpty && isZero(value) {
+		if info.OmitEmpty && isZero(value) && !ignoreOmitempty {
 			continue
 		}
 		e.addElem(info.Key, value, info.MinSize)


### PR DESCRIPTION
Currently we have `bson.SetJSONTagFallback` to fallback to json tag when no bson tag available, which is pretty useful when using `protobuf` with `mgo`, leave generated `*.pb.go` untouched and get a consistent field name between json & bson.

With the default `omitempty` tag generated by `protobuf`, updated struct fields with empty values will not be encoded, leave the database untouched. Adding a switch for ignoring `omitempty` will gain another benefit that we can keep `protobuf` performant and make updating operations easier.