### PR TITLE
allow pointer to struct in inline mode

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -746,6 +746,14 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					return nil, errors.New("Option ,inline needs a map with string keys in struct " + st.String())
 				}
 				inlineMap = info.Num
+			case reflect.Ptr:
+				// allow only pointer to struct
+				if field.Type.Elem().Kind() != reflect.Struct {
+					break
+				}
+
+				field.Type = field.Type.Elem()
+				fallthrough
 			case reflect.Struct:
 				sinfo, err := getStructInfo(field.Type)
 				if err != nil {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -267,6 +267,42 @@ func (s *S) TestMarshalBuffer(c *C) {
 	c.Assert(data, DeepEquals, buf[:len(data)])
 }
 
+func (s *S) TestPtrInline(c *C) {
+	cases := []struct {
+		In  interface{}
+		Out bson.M
+	}{
+		{
+			In:  inlinePtrStruct{A: 1, MStruct: &MStruct{M: 3}},
+			Out: bson.M{"a": 1, "m": 3},
+		},
+		{ // go deeper
+			In:  inlinePtrPtrStruct{B: 10, inlinePtrStruct: &inlinePtrStruct{A: 20, MStruct: &MStruct{M: 30}}},
+			Out: bson.M{"b": 10, "a": 20, "m": 30},
+		},
+		{
+			// nil embed struct
+			In: &inlinePtrStruct{A: 3},
+			Out: bson.M{"a": 3},
+		},
+		{
+			// nil embed struct
+			In: &inlinePtrPtrStruct{B: 5},
+			Out: bson.M{"b": 5},
+		},
+	}
+
+	for _, cs := range cases {
+		data, err := bson.Marshal(cs.In)
+		c.Assert(err, IsNil)
+		var dataBSON bson.M
+		err = bson.Unmarshal(data, &dataBSON)
+		c.Assert(err, IsNil)
+
+		c.Assert(dataBSON, DeepEquals, cs.Out)
+	}
+}
+
 // --------------------------------------------------------------------------
 // Some one way marshaling operations which would unmarshal differently.
 
@@ -678,8 +714,6 @@ var marshalErrorItems = []testItemType{
 		"Attempted to marshal empty Raw document"},
 	{bson.M{"w": bson.Raw{Kind: 0x3, Data: []byte{}}},
 		"Attempted to marshal empty Raw document"},
-	{&inlineCantPtr{&struct{ A, B int }{1, 2}},
-		"Option ,inline needs a struct value or map field"},
 	{&inlineDupName{1, struct{ A, B int }{2, 3}},
 		"Duplicated key 'a' in struct bson_test.inlineDupName"},
 	{&inlineDupMap{},
@@ -1109,9 +1143,6 @@ type shortNonEmptyInt struct {
 type inlineInt struct {
 	V struct{ A, B int } `bson:",inline"`
 }
-type inlineCantPtr struct {
-	V *struct{ A, B int } `bson:",inline"`
-}
 type inlineDupName struct {
 	A int
 	V struct{ A, B int } `bson:",inline"`
@@ -1138,6 +1169,17 @@ type inlineBadKeyMap struct {
 type inlineUnexported struct {
 	M          map[string]interface{} `bson:",inline"`
 	unexported `bson:",inline"`
+}
+type MStruct struct {
+	M int `bson:"m,omitempty"`
+}
+type inlinePtrStruct struct {
+	A int
+	*MStruct `bson:",inline"`
+}
+type inlinePtrPtrStruct struct {
+	B int
+	*inlinePtrStruct `bson:",inline"`
 }
 type unexported struct {
 	A int

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -220,13 +220,34 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.Inline == nil {
 			value = v.Field(info.Num)
 		} else {
-			value = v.FieldByIndex(info.Inline)
+			field, errField := safeFieldByIndex(v, info.Inline)
+			if errField != nil {
+				continue
+			}
+
+			value = field
 		}
 		if info.OmitEmpty && isZero(value) {
 			continue
 		}
 		e.addElem(info.Key, value, info.MinSize)
 	}
+}
+
+func safeFieldByIndex(v reflect.Value, index []int) (result reflect.Value, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch r := recovered.(type) {
+			case string:
+				err = fmt.Errorf("%s", r)
+			case error:
+				err = r
+			}
+		}
+	}()
+
+	result = v.FieldByIndex(index)
+	return
 }
 
 func isZero(v reflect.Value) bool {


### PR DESCRIPTION
BSON encoder doesn't allow to use pointers to struct in `inline` mode.

There was an issue on the same topic on old repo:
https://github.com/go-mgo/mgo/issues/346

Such structure:
```golang
type MStruct struct {
	M int `bson:"m,omitempty"`
}
type inlinePtrStruct struct {
	A int
	*MStruct `bson:",inline"`
}
```
is assumed to become `{"a":0, "m":0}` (without `mstruct` structure) - the same way as `json` encoder does it

without fix we get: "reflect: indirection through nil pointer to embedded struct"