### PR TITLE
allow ptr in inline structs

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -746,6 +746,14 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					return nil, errors.New("Option ,inline needs a map with string keys in struct " + st.String())
 				}
 				inlineMap = info.Num
+			case reflect.Ptr:
+				// allow only pointer to struct
+				if field.Type.Elem().Kind() != reflect.Struct {
+					break
+				}
+
+				field.Type = field.Type.Elem()
+				fallthrough
 			case reflect.Struct:
 				sinfo, err := getStructInfo(field.Type)
 				if err != nil {

--- a/bson/bson.go
+++ b/bson/bson.go
@@ -748,8 +748,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				inlineMap = info.Num
 			case reflect.Ptr:
 				// allow only pointer to struct
-				if field.Type.Elem().Kind() != reflect.Struct {
-					break
+				if kind := field.Type.Elem().Kind(); kind != reflect.Struct {
+					return nil, errors.New("Option ,inline allows a pointer only to a struct, was given pointer to " + kind.String())
 				}
 
 				field.Type = field.Type.Elem()
@@ -773,7 +773,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					fieldsList = append(fieldsList, finfo)
 				}
 			default:
-				panic("Option ,inline needs a struct value or map field")
+				panic("Option ,inline needs a struct value or a pointer to a struct or map field")
 			}
 			continue
 		}

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -229,6 +229,12 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.Inline == nil {
 			value = v.Field(info.Num)
 		} else {
+			// as pointers to struct are allowed here,
+			// there is no guarantee that pointer won't be nil.
+			//
+			// It is expected allowed behaviour
+			// so info.Inline MAY consist index to a nil pointer
+			// and that is why we safely call v.FieldByIndex and just continue on panic
 			field, errField := safeFieldByIndex(v, info.Inline)
 			if errField != nil {
 				continue

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -229,13 +229,34 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.Inline == nil {
 			value = v.Field(info.Num)
 		} else {
-			value = v.FieldByIndex(info.Inline)
+			field, errField := safeFieldByIndex(v, info.Inline)
+			if errField != nil {
+				continue
+			}
+
+			value = field
 		}
 		if info.OmitEmpty && isZero(value) {
 			continue
 		}
 		e.addElem(info.Key, value, info.MinSize)
 	}
+}
+
+func safeFieldByIndex(v reflect.Value, index []int) (result reflect.Value, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch r := recovered.(type) {
+			case string:
+				err = fmt.Errorf("%s", r)
+			case error:
+				err = r
+			}
+		}
+	}()
+
+	result = v.FieldByIndex(index)
+	return
 }
 
 func isZero(v reflect.Value) bool {


### PR DESCRIPTION
BSON encoder doesn't allow to use pointers to struct in `inline` mode.

There was an issue on the same topic on old repo:
https://github.com/go-mgo/mgo/issues/346

Such structure:
```golang
type MStruct struct {
	M int `bson:"m,omitempty"`
}
type inlinePtrStruct struct {
	A int
	*MStruct `bson:",inline"`
}
```
is assumed to become `{"a":0, "m":0}` (without `mstruct` structure) - the same way as `json` encoder does it

without fix we get: "reflect: indirection through nil pointer to embedded struct"