### PR TITLE
dbtest: Use os.Kill on Windows instead of os.Interrupt

### DIFF
--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -70,7 +71,7 @@ func (dbs *DBServer) start() {
 	err = dbs.server.Start()
 	if err != nil {
 		// print error to facilitate troubleshooting as the panic will be caught in a panic handler
-		fmt.Fprintf(os.Stderr, "mongod failed to start: %v\n",err)
+		fmt.Fprintf(os.Stderr, "mongod failed to start: %v\n", err)
 		panic(err)
 	}
 	dbs.tomb.Go(dbs.monitor)
@@ -113,7 +114,12 @@ func (dbs *DBServer) Stop() {
 	}
 	if dbs.server != nil {
 		dbs.tomb.Kill(nil)
-		dbs.server.Process.Signal(os.Interrupt)
+		// Windows doesn't support Interrupt
+		if runtime.GOOS == "windows" {
+			dbs.server.Process.Signal(os.Kill)
+		} else {
+			dbs.server.Process.Signal(os.Interrupt)
+		}
 		select {
 		case <-dbs.tomb.Dead():
 		case <-time.After(5 * time.Second):


### PR DESCRIPTION
# os.Interrupt signal doesn't work on Windows.

This issue has frozen on Golang community due to age. They instruct the use of os.Kill when working with signals on Windows. That's the case for dbtest package.

I've stumbled upon this when working with a Wrapper for this DBServer and testing the dbserver.Stop() function. It doesn't stop the process on Windows (where I work), and panic due to timeout.

With this change, my tests work now in Windows. I didn't change the behavior of other systems.