### PR TITLE
Separate read/write network timeouts

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -48,20 +48,18 @@ import (
 
 type mongoCluster struct {
 	sync.RWMutex
-	serverSynced  sync.Cond
-	userSeeds     []string
-	dynaSeeds     []string
-	servers       mongoServers
-	masters       mongoServers
-	references    int
-	syncing       bool
-	syncCount     uint
-	cachedIndex   map[string]bool
-	sync          chan bool
-	dial          dialer
-	minPoolSize   int
-	maxIdleTimeMS int
-	dialInfo      *DialInfo
+	serverSynced sync.Cond
+	userSeeds    []string
+	dynaSeeds    []string
+	servers      mongoServers
+	masters      mongoServers
+	references   int
+	syncing      bool
+	syncCount    uint
+	cachedIndex  map[string]bool
+	sync         chan bool
+	dial         dialer
+	dialInfo     *DialInfo
 }
 
 func newCluster(userSeeds []string, info *DialInfo) *mongoCluster {

--- a/cluster.go
+++ b/cluster.go
@@ -623,13 +623,6 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 	cluster.Unlock()
 }
 
-// AcquireSocket returns a socket to a server in the cluster.  If slaveOk is
-// true, it will attempt to return a socket to a slave server.  If it is
-// false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
-	return cluster.AcquireSocketWithPoolTimeout(mode, slaveOk, syncTimeout, socketTimeout, serverTags, poolLimit, 0)
-}
-
 // AcquireSocketWithPoolTimeout returns a socket to a server in the cluster.  If slaveOk is
 // true, it will attempt to return a socket to a slave server.  If it is
 // false, the socket will necessarily be to a master server.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1055,8 +1055,6 @@ func (s *S) TestSocketTimeoutOnDial(c *C) {
 
 	timeout := 1 * time.Second
 
-	defer mgo.HackSyncSocketTimeout(timeout)()
-
 	s.Freeze("localhost:40001")
 
 	started := time.Now()

--- a/export_test.go
+++ b/export_test.go
@@ -19,20 +19,6 @@ func HackPingDelay(newDelay time.Duration) (restore func()) {
 	return
 }
 
-func HackSyncSocketTimeout(newTimeout time.Duration) (restore func()) {
-	globalMutex.Lock()
-	defer globalMutex.Unlock()
-
-	oldTimeout := syncSocketTimeout
-	restore = func() {
-		globalMutex.Lock()
-		syncSocketTimeout = oldTimeout
-		globalMutex.Unlock()
-	}
-	syncSocketTimeout = newTimeout
-	return
-}
-
 func (s *Session) Cluster() *mongoCluster {
 	return s.cluster()
 }

--- a/server.go
+++ b/server.go
@@ -565,7 +565,7 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		if best == nil {
 			best = next
 			best.RLock()
-			if serverTags != nil && !next.info.Mongos && !best.hasTags(serverTags) {
+			if len(serverTags) != 0 && !next.info.Mongos && !best.hasTags(serverTags) {
 				best.RUnlock()
 				best = nil
 			}
@@ -574,7 +574,7 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		next.RLock()
 		swap := false
 		switch {
-		case serverTags != nil && !next.info.Mongos && !next.hasTags(serverTags):
+		case len(serverTags) != 0 && !next.info.Mongos && !next.hasTags(serverTags):
 			// Must have requested tags.
 		case mode == Secondary && next.info.Master && !next.info.Mongos:
 			// Must be a secondary or mongos.

--- a/server.go
+++ b/server.go
@@ -140,7 +140,7 @@ func (server *mongoServer) acquireSocketInternal(info *DialInfo, shouldBlock boo
 			server.Unlock()
 			return nil, abended, errServerClosed
 		}
-		if info.poolLimit() > 0 {
+		if info.PoolLimit > 0 {
 			if shouldBlock {
 				// Beautiful. Golang conditions don't have a WaitWithTimeout, so I've implemented the timeout
 				// with a wait + broadcast. The broadcast will cause the loop here to re-check the timeout,
@@ -166,7 +166,7 @@ func (server *mongoServer) acquireSocketInternal(info *DialInfo, shouldBlock boo
 					}()
 				}
 				timeSpentWaiting := time.Duration(0)
-				for len(server.liveSockets)-len(server.unusedSockets) >= info.poolLimit() && !timeoutHit {
+				for len(server.liveSockets)-len(server.unusedSockets) >= info.PoolLimit && !timeoutHit {
 					// We only count time spent in Wait(), and not time evaluating the entire loop,
 					// so that in the happy non-blocking path where the condition above evaluates true
 					// first time, we record a nice round zero wait time.
@@ -185,7 +185,7 @@ func (server *mongoServer) acquireSocketInternal(info *DialInfo, shouldBlock boo
 				// Record that we fetched a connection of of a socket list and how long we spent waiting
 				stats.noticeSocketAcquisition(timeSpentWaiting)
 			} else {
-				if len(server.liveSockets)-len(server.unusedSockets) >= info.poolLimit() {
+				if len(server.liveSockets)-len(server.unusedSockets) >= info.PoolLimit {
 					server.Unlock()
 					return nil, false, errPoolLimit
 				}

--- a/server_test.go
+++ b/server_test.go
@@ -29,8 +29,8 @@ package mgo_test
 import (
 	"time"
 
-	. "gopkg.in/check.v1"
 	"github.com/globalsign/mgo"
+	. "gopkg.in/check.v1"
 )
 
 func (s *S) TestServerRecoversFromAbend(c *C) {
@@ -53,8 +53,8 @@ func (s *S) TestServerRecoversFromAbend(c *C) {
 	c.Assert(err, IsNil)
 	sock.Release()
 	c.Check(abended, Equals, true)
-	// cluster.AcquireSocket should fix the abended problems
-	sock, err = cluster.AcquireSocket(mgo.Primary, false, time.Minute, time.Second, nil, 100)
+	// cluster.AcquireSocketWithPoolTimeout should fix the abended problems
+	sock, err = cluster.AcquireSocketWithPoolTimeout(mgo.Primary, false, time.Minute, time.Second, nil, 100)
 	c.Assert(err, IsNil)
 	sock.Release()
 	sock, abended, err = server.AcquireSocket(100, time.Second)

--- a/server_test.go
+++ b/server_test.go
@@ -40,7 +40,13 @@ func (s *S) TestServerRecoversFromAbend(c *C) {
 	// Peek behind the scenes
 	cluster := session.Cluster()
 	server := cluster.Server("127.0.0.1:40001")
-	sock, abended, err := server.AcquireSocket(100, time.Second)
+
+	info := &mgo.DialInfo{
+		Timeout: time.Second,
+		PoolLimit: 100,
+	}
+	
+	sock, abended, err := server.AcquireSocket(info)
 	c.Assert(err, IsNil)
 	c.Assert(sock, NotNil)
 	sock.Release()
@@ -49,15 +55,15 @@ func (s *S) TestServerRecoversFromAbend(c *C) {
 	sock.Close()
 	server.AbendSocket(sock)
 	// Next acquire notices the connection was abnormally ended
-	sock, abended, err = server.AcquireSocket(100, time.Second)
+	sock, abended, err = server.AcquireSocket(info)
 	c.Assert(err, IsNil)
 	sock.Release()
 	c.Check(abended, Equals, true)
 	// cluster.AcquireSocketWithPoolTimeout should fix the abended problems
-	sock, err = cluster.AcquireSocketWithPoolTimeout(mgo.Primary, false, time.Minute, time.Second, nil, 100)
+	sock, err = cluster.AcquireSocketWithPoolTimeout(mgo.Primary, false, time.Minute, nil, info)
 	c.Assert(err, IsNil)
 	sock.Release()
-	sock, abended, err = server.AcquireSocket(100, time.Second)
+	sock, abended, err = server.AcquireSocket(info)
 	c.Assert(err, IsNil)
 	c.Check(abended, Equals, false)
 	sock.Release()

--- a/session.go
+++ b/session.go
@@ -598,8 +598,7 @@ func (i *DialInfo) Copy() *DialInfo {
 	return info
 }
 
-// readTimeout returns the configured read timeout, or DefaultReadTimeout if
-// unset.
+// readTimeout returns the configured read timeout, or i.Timeout if it's not set
 func (i *DialInfo) readTimeout() time.Duration {
 	if i.ReadTimeout == zeroDuration {
 		return i.Timeout
@@ -607,8 +606,8 @@ func (i *DialInfo) readTimeout() time.Duration {
 	return i.ReadTimeout
 }
 
-// writeTimeout returns the configured write timeout, or DefaultWriteTimeout if
-// unset.
+// writeTimeout returns the configured write timeout, or i.Timeout if it's not
+// set
 func (i *DialInfo) writeTimeout() time.Duration {
 	if i.WriteTimeout == zeroDuration {
 		return i.Timeout

--- a/session.go
+++ b/session.go
@@ -74,21 +74,11 @@ const (
 	// Strong mode is specific to mgo, and is same as Primary.
 	Strong Mode = 2
 
-	// DefaultConnectionPoolSize defines the default maximum number of
+	// DefaultConnectionPoolLimit defines the default maximum number of
 	// connections in the connection pool.
 	//
 	// To override this value set DialInfo.PoolLimit.
-	DefaultConnectionPoolSize = 4096
-
-	// DefaultReadTimeout is set to 60 seconds for backwards compatibility.
-	//
-	// See DialInfo.ReadTimeout
-	DefaultReadTimeout = time.Second * 60
-
-	// DefaultWriteTimeout is set to 60 seconds for backwards compatibility.
-	//
-	// See DialInfo.WriteTimeout
-	DefaultWriteTimeout = time.Second * 60
+	DefaultConnectionPoolLimit = 4096
 
 	zeroDuration = time.Duration(0)
 )
@@ -501,7 +491,7 @@ type DialInfo struct {
 	Password string
 
 	// PoolLimit defines the per-server socket pool limit. Defaults to
-	// DefaultConnectionPoolSize. See Session.SetPoolLimit for details.
+	// DefaultConnectionPoolLimit. See Session.SetPoolLimit for details.
 	PoolLimit int
 
 	// PoolTimeout defines max time to wait for a connection to become available
@@ -509,8 +499,8 @@ type DialInfo struct {
 	// Session.SetPoolTimeout for details
 	PoolTimeout time.Duration
 
-	// ReadTimeout defines the maximum duration to wait for a response from
-	// MongoDB.
+	// ReadTimeout defines the maximum duration to wait for a response to be
+	// read from MongoDB.
 	//
 	// This effectively limits the maximum query execution time. If a MongoDB
 	// query duration exceeds this timeout, the caller will receive a timeout,

--- a/session.go
+++ b/session.go
@@ -73,6 +73,24 @@ const (
 	Monotonic Mode = 1
 	// Strong mode is specific to mgo, and is same as Primary.
 	Strong Mode = 2
+
+	// DefaultConnectionPoolSize defines the default maximum number of
+	// connections in the connection pool.
+	//
+	// To override this value set DialInfo.PoolLimit.
+	DefaultConnectionPoolSize = 4096
+
+	// DefaultReadTimeout is set to 60 seconds for backwards compatibility.
+	//
+	// See DialInfo.ReadTimeout
+	DefaultReadTimeout = time.Second * 60
+
+	// DefaultWriteTimeout is set to 60 seconds for backwards compatibility.
+	//
+	// See DialInfo.WriteTimeout
+	DefaultWriteTimeout = time.Second * 60
+
+	zeroDuration = time.Duration(0)
 )
 
 // mgo.v3: Drop Strong mode, suffix all modes with "Mode".
@@ -90,9 +108,6 @@ type Session struct {
 	defaultdb        string
 	sourcedb         string
 	syncTimeout      time.Duration
-	sockTimeout      time.Duration
-	poolLimit        int
-	poolTimeout      time.Duration
 	consistency      Mode
 	creds            []Credential
 	dialCred         *Credential
@@ -104,6 +119,8 @@ type Session struct {
 	queryConfig      query
 	bypassValidation bool
 	slaveOk          bool
+
+	dialInfo *DialInfo
 }
 
 // Database holds collections of documents
@@ -196,7 +213,7 @@ const (
 // Dial will timeout after 10 seconds if a server isn't reached. The returned
 // session will timeout operations after one minute by default if servers aren't
 // available. To customize the timeout, see DialWithTimeout, SetSyncTimeout, and
-// SetSocketTimeout.
+// DialInfo Read/WriteTimeout.
 //
 // This method is generally called just once for a given cluster.  Further
 // sessions to the same cluster are then established using the New or Copy
@@ -483,14 +500,37 @@ type DialInfo struct {
 	Username string
 	Password string
 
-	// PoolLimit defines the per-server socket pool limit. Defaults to 4096.
-	// See Session.SetPoolLimit for details.
+	// PoolLimit defines the per-server socket pool limit. Defaults to
+	// DefaultConnectionPoolSize. See Session.SetPoolLimit for details.
 	PoolLimit int
 
 	// PoolTimeout defines max time to wait for a connection to become available
-	// if the pool limit is reaqched. Defaults to zero, which means forever.
-	// See Session.SetPoolTimeout for details
+	// if the pool limit is reached. Defaults to zero, which means forever. See
+	// Session.SetPoolTimeout for details
 	PoolTimeout time.Duration
+
+	// ReadTimeout defines the maximum duration to wait for a response from
+	// MongoDB.
+	//
+	// This effectively limits the maximum query execution time. If a MongoDB
+	// query duration exceeds this timeout, the caller will receive a timeout,
+	// however MongoDB will continue processing the query. This duration must be
+	// large enough to allow MongoDB to execute the query, and the response be
+	// received over the network connection.
+	//
+	// Only limits the network read - does not include unmarshalling /
+	// processing of the response. Defaults to DialInfo.Timeout. If 0, no
+	// timeout is set.
+	ReadTimeout time.Duration
+
+	// WriteTimeout defines the maximum duration of a write to MongoDB over the
+	// network connection.
+	//
+	// This is can usually be low unless writing large documents, or over a high
+	// latency link. Only limits network write time - does not include
+	// marshalling/processing the request. Defaults to DialInfo.Timeout. If 0,
+	// no timeout is set.
+	WriteTimeout time.Duration
 
 	// The identifier of the client application which ran the operation.
 	AppName string
@@ -527,6 +567,80 @@ type DialInfo struct {
 	Dial func(addr net.Addr) (net.Conn, error)
 }
 
+// Copy returns a deep-copy of i.
+func (i *DialInfo) Copy() *DialInfo {
+	var readPreference *ReadPreference
+	if i.ReadPreference != nil {
+		readPreference = &ReadPreference{
+			Mode: i.ReadPreference.Mode,
+		}
+		readPreference.TagSets = make([]bson.D, len(i.ReadPreference.TagSets))
+		copy(readPreference.TagSets, i.ReadPreference.TagSets)
+	}
+
+	info := &DialInfo{
+		Timeout:        i.Timeout,
+		Database:       i.Database,
+		ReplicaSetName: i.ReplicaSetName,
+		Source:         i.Source,
+		Service:        i.Service,
+		ServiceHost:    i.ServiceHost,
+		Mechanism:      i.Mechanism,
+		Username:       i.Username,
+		Password:       i.Password,
+		PoolLimit:      i.PoolLimit,
+		PoolTimeout:    i.PoolTimeout,
+		ReadTimeout:    i.ReadTimeout,
+		WriteTimeout:   i.WriteTimeout,
+		AppName:        i.AppName,
+		ReadPreference: readPreference,
+		FailFast:       i.FailFast,
+		Direct:         i.Direct,
+		MinPoolSize:    i.MinPoolSize,
+		MaxIdleTimeMS:  i.MaxIdleTimeMS,
+		DialServer:     i.DialServer,
+		Dial:           i.Dial,
+	}
+
+	info.Addrs = make([]string, len(i.Addrs))
+	copy(info.Addrs, i.Addrs)
+
+	return info
+}
+
+// readTimeout returns the configured read timeout, or DefaultReadTimeout if
+// unset.
+func (i *DialInfo) readTimeout() time.Duration {
+	if i.ReadTimeout == zeroDuration {
+		return i.Timeout
+	}
+	return i.ReadTimeout
+}
+
+// writeTimeout returns the configured write timeout, or DefaultWriteTimeout if
+// unset.
+func (i *DialInfo) writeTimeout() time.Duration {
+	if i.WriteTimeout == zeroDuration {
+		return i.Timeout
+	}
+	return i.WriteTimeout
+}
+
+// roundTripTimeout returns the total time allocated for a single network read
+// and write.
+func (i *DialInfo) roundTripTimeout() time.Duration {
+	return i.readTimeout() + i.writeTimeout()
+}
+
+// poolLimit returns the configured connection pool size, or
+// DefaultConnectionPoolSize.
+func (i *DialInfo) poolLimit() int {
+	if i == nil || i.PoolLimit == 0 {
+		return DefaultConnectionPoolSize
+	}
+	return i.PoolLimit
+}
+
 // ReadPreference defines the manner in which servers are chosen.
 type ReadPreference struct {
 	// Mode determines the consistency of results. See Session.SetMode.
@@ -556,7 +670,8 @@ func (addr *ServerAddr) TCPAddr() *net.TCPAddr {
 }
 
 // DialWithInfo establishes a new session to the cluster identified by info.
-func DialWithInfo(info *DialInfo) (*Session, error) {
+func DialWithInfo(dialInfo *DialInfo) (*Session, error) {
+	info := dialInfo.Copy()
 	addrs := make([]string, len(info.Addrs))
 	for i, addr := range info.Addrs {
 		p := strings.LastIndexAny(addr, "]:")
@@ -567,7 +682,7 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 		addrs[i] = addr
 	}
 	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer}, info.ReplicaSetName, info.AppName)
-	session := newSession(Eventual, cluster, info.Timeout)
+	session := newSession(Eventual, cluster, info)
 	session.defaultdb = info.Database
 	if session.defaultdb == "" {
 		session.defaultdb = "test"
@@ -595,17 +710,9 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 		}
 		session.creds = []Credential{*session.dialCred}
 	}
-	if info.PoolLimit > 0 {
-		session.poolLimit = info.PoolLimit
-	}
 
 	cluster.minPoolSize = info.MinPoolSize
 	cluster.maxIdleTimeMS = info.MaxIdleTimeMS
-
-	if info.PoolTimeout > 0 {
-		session.poolTimeout = info.PoolTimeout
-	}
-
 	cluster.Release()
 
 	// People get confused when we return a session that is not actually
@@ -623,6 +730,8 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 	} else {
 		session.SetMode(Strong, true)
 	}
+
+	session.dialInfo = info
 
 	return session, nil
 }
@@ -684,13 +793,12 @@ func extractURL(s string) (*urlInfo, error) {
 	return info, nil
 }
 
-func newSession(consistency Mode, cluster *mongoCluster, timeout time.Duration) (session *Session) {
+func newSession(consistency Mode, cluster *mongoCluster, info *DialInfo) (session *Session) {
 	cluster.Acquire()
 	session = &Session{
 		mgoCluster:  cluster,
-		syncTimeout: timeout,
-		sockTimeout: timeout,
-		poolLimit:   4096,
+		syncTimeout: info.Timeout,
+		dialInfo:    info,
 	}
 	debugf("New session %p on cluster %p", session, cluster)
 	session.SetMode(consistency, true)
@@ -719,9 +827,6 @@ func copySession(session *Session, keepCreds bool) (s *Session) {
 		defaultdb:        session.defaultdb,
 		sourcedb:         session.sourcedb,
 		syncTimeout:      session.syncTimeout,
-		sockTimeout:      session.sockTimeout,
-		poolLimit:        session.poolLimit,
-		poolTimeout:      session.poolTimeout,
 		consistency:      session.consistency,
 		creds:            creds,
 		dialCred:         session.dialCred,
@@ -733,6 +838,7 @@ func copySession(session *Session, keepCreds bool) (s *Session) {
 		queryConfig:      session.queryConfig,
 		bypassValidation: session.bypassValidation,
 		slaveOk:          session.slaveOk,
+		dialInfo:         session.dialInfo,
 	}
 	s = &scopy
 	debugf("New session %p on cluster %p (copy from %p)", s, cluster, session)
@@ -2018,13 +2124,21 @@ func (s *Session) SetSyncTimeout(d time.Duration) {
 	s.m.Unlock()
 }
 
-// SetSocketTimeout sets the amount of time to wait for a non-responding
-// socket to the database before it is forcefully closed.
+// SetSocketTimeout is deprecated - use DialInfo read/write timeouts instead.
+//
+// SetSocketTimeout sets the amount of time to wait for a non-responding socket
+// to the database before it is forcefully closed.
 //
 // The default timeout is 1 minute.
 func (s *Session) SetSocketTimeout(d time.Duration) {
 	s.m.Lock()
-	s.sockTimeout = d
+
+	// Set both the read and write timeout, as well as the DialInfo.Timeout for
+	// backwards compatibility,
+	s.dialInfo.Timeout = d
+	s.dialInfo.ReadTimeout = d
+	s.dialInfo.WriteTimeout = d
+
 	if s.masterSocket != nil {
 		s.masterSocket.SetTimeout(d)
 	}
@@ -2058,7 +2172,7 @@ func (s *Session) SetCursorTimeout(d time.Duration) {
 // of used resources and number of goroutines before they are created.
 func (s *Session) SetPoolLimit(limit int) {
 	s.m.Lock()
-	s.poolLimit = limit
+	s.dialInfo.PoolLimit = limit
 	s.m.Unlock()
 }
 
@@ -2068,7 +2182,7 @@ func (s *Session) SetPoolLimit(limit int) {
 // The default value is zero, which means to wait forever with no timeout.
 func (s *Session) SetPoolTimeout(timeout time.Duration) {
 	s.m.Lock()
-	s.poolTimeout = timeout
+	s.dialInfo.PoolTimeout = timeout
 	s.m.Unlock()
 }
 
@@ -4356,9 +4470,11 @@ func (iter *Iter) acquireSocket() (*mongoSocket, error) {
 		// with Eventual sessions, if a Refresh is done, or if a
 		// monotonic session gets a write and shifts from secondary
 		// to primary. Our cursor is in a specific server, though.
+
 		iter.session.m.Lock()
-		sockTimeout := iter.session.sockTimeout
+		sockTimeout := iter.session.dialInfo.roundTripTimeout()
 		iter.session.m.Unlock()
+
 		socket.Release()
 		socket, _, err = iter.server.AcquireSocket(0, sockTimeout)
 		if err != nil {
@@ -4950,7 +5066,11 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 
 	// Still not good.  We need a new socket.
 	sock, err := s.cluster().AcquireSocketWithPoolTimeout(
-		s.consistency, slaveOk && s.slaveOk, s.syncTimeout, s.sockTimeout, s.queryConfig.op.serverTags, s.poolLimit, s.poolTimeout,
+		s.consistency,
+		slaveOk && s.slaveOk,
+		s.syncTimeout,
+		s.queryConfig.op.serverTags,
+		s.dialInfo,
 	)
 	if err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -555,7 +555,7 @@ type DialInfo struct {
 	// Defaults to 0.
 	MinPoolSize int
 
-	//The maximum number of milliseconds that a connection can remain idle in the pool
+	// The maximum number of milliseconds that a connection can remain idle in the pool
 	// before being removed and closed.
 	MaxIdleTimeMS int
 
@@ -681,7 +681,7 @@ func DialWithInfo(dialInfo *DialInfo) (*Session, error) {
 		}
 		addrs[i] = addr
 	}
-	cluster := newCluster(addrs, info.Direct, info.FailFast, dialer{info.Dial, info.DialServer}, info.ReplicaSetName, info.AppName)
+	cluster := newCluster(addrs, info)
 	session := newSession(Eventual, cluster, info)
 	session.defaultdb = info.Database
 	if session.defaultdb == "" {
@@ -4472,11 +4472,11 @@ func (iter *Iter) acquireSocket() (*mongoSocket, error) {
 		// to primary. Our cursor is in a specific server, though.
 
 		iter.session.m.Lock()
-		sockTimeout := iter.session.dialInfo.roundTripTimeout()
+		info := iter.session.dialInfo
 		iter.session.m.Unlock()
 
 		socket.Release()
-		socket, _, err = iter.server.AcquireSocket(0, sockTimeout)
+		socket, _, err = iter.server.AcquireSocket(info)
 		if err != nil {
 			return nil, err
 		}

--- a/session.go
+++ b/session.go
@@ -633,10 +633,10 @@ func (i *DialInfo) roundTripTimeout() time.Duration {
 }
 
 // poolLimit returns the configured connection pool size, or
-// DefaultConnectionPoolSize.
+// DefaultConnectionPoolLimit.
 func (i *DialInfo) poolLimit() int {
-	if i == nil || i.PoolLimit == 0 {
-		return DefaultConnectionPoolSize
+	if i.PoolLimit == 0 {
+		return DefaultConnectionPoolLimit
 	}
 	return i.PoolLimit
 }
@@ -672,6 +672,10 @@ func (addr *ServerAddr) TCPAddr() *net.TCPAddr {
 // DialWithInfo establishes a new session to the cluster identified by info.
 func DialWithInfo(dialInfo *DialInfo) (*Session, error) {
 	info := dialInfo.Copy()
+	info.PoolLimit = info.poolLimit()
+	info.ReadTimeout = info.readTimeout()
+	info.WriteTimeout = info.writeTimeout()
+
 	addrs := make([]string, len(info.Addrs))
 	for i, addr := range info.Addrs {
 		p := strings.LastIndexAny(addr, "]:")

--- a/session.go
+++ b/session.go
@@ -711,8 +711,6 @@ func DialWithInfo(dialInfo *DialInfo) (*Session, error) {
 		session.creds = []Credential{*session.dialCred}
 	}
 
-	cluster.minPoolSize = info.MinPoolSize
-	cluster.maxIdleTimeMS = info.MaxIdleTimeMS
 	cluster.Release()
 
 	// People get confused when we return a session that is not actually

--- a/session_internal_test.go
+++ b/session_internal_test.go
@@ -3,9 +3,11 @@ package mgo
 import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"testing"
+	"time"
+
 	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type S struct{}
@@ -61,4 +63,23 @@ func (s *S) TestGetRFC2253NameStringMultiValued(c *C) {
 	}
 
 	c.Assert(getRFC2253NameString(&RDNElements), Equals, "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US")
+}
+
+func (s *S) TestDialTimeouts(c *C) {
+	info := &DialInfo{}
+
+	c.Assert(info.readTimeout(), Equals, time.Duration(0))
+	c.Assert(info.writeTimeout(), Equals, time.Duration(0))
+	c.Assert(info.roundTripTimeout(), Equals, time.Duration(0))
+
+	info.Timeout = 60 * time.Second
+	c.Assert(info.readTimeout(), Equals, 60*time.Second)
+	c.Assert(info.writeTimeout(), Equals, 60*time.Second)
+	c.Assert(info.roundTripTimeout(), Equals, 120*time.Second)
+
+	info.ReadTimeout = time.Second
+	c.Assert(info.readTimeout(), Equals, time.Second)
+
+	info.WriteTimeout = time.Second
+	c.Assert(info.writeTimeout(), Equals, time.Second)
 }

--- a/session_test.go
+++ b/session_test.go
@@ -4969,6 +4969,19 @@ func (s *S) TestCollationQueries(c *C) {
 	}
 }
 
+func (s *S) TestDialTimeouts(c *C) {
+	info := &mgo.DialInfo{}
+
+	c.Assert(info.readTimeout(), Equals, mgo.DefaultReadTimeout)
+	c.Assert(info.writeTimeout(), Equals, mgo.DefaultWriteTimeout)
+
+	info.ReadTimeout = time.Second
+	c.Assert(info.readTimeout(), Equals, time.Second)
+
+	info.WriteTimewut = time.Second
+	c.Assert(info.writeTimeout(), Equals, time.Second)
+}
+
 // --------------------------------------------------------------------------
 // Some benchmarks that require a running database.
 

--- a/session_test.go
+++ b/session_test.go
@@ -4969,19 +4969,6 @@ func (s *S) TestCollationQueries(c *C) {
 	}
 }
 
-func (s *S) TestDialTimeouts(c *C) {
-	info := &mgo.DialInfo{}
-
-	c.Assert(info.readTimeout(), Equals, mgo.DefaultReadTimeout)
-	c.Assert(info.writeTimeout(), Equals, mgo.DefaultWriteTimeout)
-
-	info.ReadTimeout = time.Second
-	c.Assert(info.readTimeout(), Equals, time.Second)
-
-	info.WriteTimewut = time.Second
-	c.Assert(info.writeTimeout(), Equals, time.Second)
-}
-
 // --------------------------------------------------------------------------
 // Some benchmarks that require a running database.
 

--- a/socket.go
+++ b/socket.go
@@ -304,37 +304,37 @@ const (
 
 func (socket *mongoSocket) updateDeadline(which deadlineType) {
 	var when time.Time
-	var whichstr string
+	var whichStr string
 	switch which {
 	case readDeadline | writeDeadline:
 		if socket.dialInfo.roundTripTimeout() == 0 {
 			return
 		}
-		whichstr = "read/write"
+		whichStr = "read/write"
 		when = time.Now().Add(socket.dialInfo.roundTripTimeout())
 		socket.conn.SetDeadline(when)
 
 	case readDeadline:
-		if socket.dialInfo.readTimeout() == 0 {
+		if socket.dialInfo.ReadTimeout == zeroDuration {
 			return
 		}
-		whichstr = "read"
-		when = time.Now().Add(socket.dialInfo.readTimeout())
+		whichStr = "read"
+		when = time.Now().Add(socket.dialInfo.ReadTimeout)
 		socket.conn.SetReadDeadline(when)
 
 	case writeDeadline:
-		if socket.dialInfo.writeTimeout() == 0 {
+		if socket.dialInfo.WriteTimeout == zeroDuration {
 			return
 		}
-		whichstr = "write"
-		when = time.Now().Add(socket.dialInfo.writeTimeout())
+		whichStr = "write"
+		when = time.Now().Add(socket.dialInfo.WriteTimeout)
 		socket.conn.SetWriteDeadline(when)
 
 	default:
 		panic("invalid parameter to updateDeadline")
 	}
 
-	debugf("Socket %p to %s: updated %s deadline to %s", socket, socket.addr, whichstr, when)
+	debugf("Socket %p to %s: updated %s deadline to %s", socket, socket.addr, whichStr, when)
 }
 
 // Close terminates the socket use.

--- a/socket.go
+++ b/socket.go
@@ -42,7 +42,6 @@ type mongoSocket struct {
 	sync.Mutex
 	server         *mongoServer // nil when cached
 	conn           net.Conn
-	timeout        time.Duration
 	addr           string // For debugging only.
 	nextRequestId  uint32
 	replyFuncs     map[uint32]replyFunc
@@ -56,6 +55,8 @@ type mongoSocket struct {
 	closeAfterIdle bool
 	lastTimeUsed   time.Time // for time based idle socket release
 	sendMeta       sync.Once
+
+	dialInfo *DialInfo
 }
 
 type queryOpFlags uint32
@@ -181,15 +182,16 @@ type requestInfo struct {
 	replyFunc replyFunc
 }
 
-func newSocket(server *mongoServer, conn net.Conn, timeout time.Duration) *mongoSocket {
+func newSocket(server *mongoServer, conn net.Conn, info *DialInfo) *mongoSocket {
 	socket := &mongoSocket{
 		conn:       conn,
 		addr:       server.Addr,
 		server:     server,
 		replyFuncs: make(map[uint32]replyFunc),
+		dialInfo:   info,
 	}
 	socket.gotNonce.L = &socket.Mutex
-	if err := socket.InitialAcquire(server.Info(), timeout); err != nil {
+	if err := socket.InitialAcquire(server.Info(), info); err != nil {
 		panic("newSocket: InitialAcquire returned error: " + err.Error())
 	}
 	stats.socketsAlive(+1)
@@ -223,7 +225,7 @@ func (socket *mongoSocket) ServerInfo() *mongoServerInfo {
 // InitialAcquire obtains the first reference to the socket, either
 // right after the connection is made or once a recycled socket is
 // being put back in use.
-func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout time.Duration) error {
+func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, dialInfo *DialInfo) error {
 	socket.Lock()
 	if socket.references > 0 {
 		panic("Socket acquired out of cache with references")
@@ -235,7 +237,7 @@ func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout t
 	}
 	socket.references++
 	socket.serverInfo = serverInfo
-	socket.timeout = timeout
+	socket.dialInfo = dialInfo
 	stats.socketsInUse(+1)
 	stats.socketRefs(+1)
 	socket.Unlock()
@@ -288,7 +290,8 @@ func (socket *mongoSocket) Release() {
 // SetTimeout changes the timeout used on socket operations.
 func (socket *mongoSocket) SetTimeout(d time.Duration) {
 	socket.Lock()
-	socket.timeout = d
+	socket.dialInfo.ReadTimeout = d
+	socket.dialInfo.WriteTimeout = d
 	socket.Unlock()
 }
 
@@ -301,24 +304,37 @@ const (
 
 func (socket *mongoSocket) updateDeadline(which deadlineType) {
 	var when time.Time
-	if socket.timeout > 0 {
-		when = time.Now().Add(socket.timeout)
-	}
-	whichstr := ""
+	var whichstr string
 	switch which {
 	case readDeadline | writeDeadline:
+		if socket.dialInfo.roundTripTimeout() == 0 {
+			return
+		}
 		whichstr = "read/write"
+		when = time.Now().Add(socket.dialInfo.roundTripTimeout())
 		socket.conn.SetDeadline(when)
+
 	case readDeadline:
+		if socket.dialInfo.readTimeout() == 0 {
+			return
+		}
 		whichstr = "read"
+		when = time.Now().Add(socket.dialInfo.readTimeout())
 		socket.conn.SetReadDeadline(when)
+
 	case writeDeadline:
+		if socket.dialInfo.writeTimeout() == 0 {
+			return
+		}
 		whichstr = "write"
+		when = time.Now().Add(socket.dialInfo.writeTimeout())
 		socket.conn.SetWriteDeadline(when)
+
 	default:
 		panic("invalid parameter to updateDeadline")
 	}
-	debugf("Socket %p to %s: updated %s deadline to %s ahead (%s)", socket, socket.addr, whichstr, socket.timeout, when)
+
+	debugf("Socket %p to %s: updated %s deadline to %s", socket, socket.addr, whichstr, when)
 }
 
 // Close terminates the socket use.


### PR DESCRIPTION
Fixes #160.

Defines two new `DialInfo` fields: `ReadTimeout`, and `WriteTimeout`, defaulting to `DialInfo.Timeout` for backwards compatibility.

Removes passing multiple copies of the timeout value throughout the codebase, instead keeping a reference to a copy of the `DialInfo` which should make future refactoring easier (all the information is available everywhere, rather than ad-hock passing in function arguments).

As a nice bonus, because the same `DialInfo` instance is referenced by all sockets rather than each socket referencing its own copy of the timeout value in the hot path, the increased cache locality has reduced operation latency by ~15% resulting in ~1700/s increase in read throughput.

---

![throughput-overview](https://user-images.githubusercontent.com/9275968/39828323-77ac97d6-53b2-11e8-89e3-689eb8a74501.png)

[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-insert-latency.txt](https://github.com/globalsign/mgo/files/1988741/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-insert-latency.txt)
[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-insert-throughput.txt](https://github.com/globalsign/mgo/files/1988742/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-insert-throughput.txt)
[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-select-zipfian-latency.txt](https://github.com/globalsign/mgo/files/1988743/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-select-zipfian-latency.txt)
[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-select-zipfian-throughput.txt](https://github.com/globalsign/mgo/files/1988744/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-select-zipfian-throughput.txt)
[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-update-zipfian-latency.txt](https://github.com/globalsign/mgo/files/1988745/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-update-zipfian-latency.txt)
[efe0945164a7e582241f37ae8983c075f8f2e870-timeout-update-zipfian-throughput.txt](https://github.com/globalsign/mgo/files/1988746/efe0945164a7e582241f37ae8983c075f8f2e870-timeout-update-zipfian-throughput.txt)
