### PR TITLE
revert: MGO-156 Avoid iter.Next deadlock on dead sockets (#182)

### DIFF
--- a/session.go
+++ b/session.go
@@ -4545,13 +4545,7 @@ func (iter *Iter) getMore() {
 	} else {
 		op = &iter.op
 	}
-	// We unlock the iterator around socket.Query because it will call the
-	// replyFunc if the socket is dead, which would deadlock if the iterator
-	// were still locked.
-	iter.m.Unlock()
-	err = socket.Query(op)
-	iter.m.Lock()
-	if err != nil {
+	if err := socket.Query(op); err != nil {
 		iter.docsToReceive--
 		iter.err = err
 	}


### PR DESCRIPTION
This reverts commit 7253b2be6df6d0d36d370c641cdbc82b8abe41d8.