### PR TITLE
Release/r2018.06.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * Supports dropping all indexes on a collection ([details](https://github.com/globalsign/mgo/pull/25))
 * Annotates log entries/profiler output with optional appName on 3.4+ ([details](https://github.com/globalsign/mgo/pull/28))
 * Support for read-only [views](https://docs.mongodb.com/manual/core/views/) in 3.4+ ([details](https://github.com/globalsign/mgo/pull/33))
-* Support for [collations](https://docs.mongodb.com/manual/reference/collation/) in 3.4+ ([details](https://github.com/globalsign/mgo/pull/37))
+* Support for [collations](https://docs.mongodb.com/manual/reference/collation/) in 3.4+ ([details](https://github.com/globalsign/mgo/pull/37), [more](https://github.com/globalsign/mgo/pull/166))
 * Provide BSON constants for convenience/sanity ([details](https://github.com/globalsign/mgo/pull/41))
 * Consistently unmarshal time.Time values as UTC ([details](https://github.com/globalsign/mgo/pull/42))
 * Enforces best practise coding guidelines ([details](https://github.com/globalsign/mgo/pull/44))
@@ -49,6 +49,15 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * Add BSON stream encoders ([details](https://github.com/globalsign/mgo/pull/127))
 * Add integer map key support in the BSON encoder ([details](https://github.com/globalsign/mgo/pull/140)) 
 * Support aggregation [collations](https://docs.mongodb.com/manual/reference/collation/) ([details](https://github.com/globalsign/mgo/pull/144))
+* Support encoding of inline struct references ([details](https://github.com/globalsign/mgo/pull/146))
+* Improved windows test harness ([details](https://github.com/globalsign/mgo/pull/158))
+* Improved type and nil handling in the BSON codec ([details](https://github.com/globalsign/mgo/pull/147/files), [more](https://github.com/globalsign/mgo/pull/181))
+* Separated network read/write timeouts ([details](https://github.com/globalsign/mgo/pull/161))
+* Expanded dial string configuration options ([details](https://github.com/globalsign/mgo/pull/162))
+* Implement MongoTimestamp ([details](https://github.com/globalsign/mgo/pull/171))
+* Support setting `writeConcern` for `findAndModify` operations ([details](https://github.com/globalsign/mgo/pull/185))
+* Add `ssl` to the dial string options ([details](https://github.com/globalsign/mgo/pull/184))
+
 
 ---
 
@@ -59,23 +68,32 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * @BenLubar
 * @carldunham
 * @carter2000
+* @cedric-cordenier
 * @cezarsa
+* @DaytonG
+* @ddspog
 * @drichelson
 * @dvic
 * @eaglerayp
 * @feliixx
 * @fmpwizard
 * @gazoon
+* @gedge
 * @gnawux
 * @idy
 * @jameinel
+* @jefferickson
 * @johnlawsharrison
 * @KJTsanaktsidis
+* @larrycinnabar
 * @mapete94
 * @maxnoel
 * @mcspring
+* @Mei-Zhao
 * @peterdeka
 * @Reenjii
+* @roobre
 * @smoya
 * @steve-gray
+* @tbruyelle
 * @wgallagher

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -32,6 +32,8 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
+	"math/rand"
 	"net/url"
 	"reflect"
 	"strings"
@@ -269,6 +271,42 @@ func (s *S) TestMarshalBuffer(c *C) {
 	data, err := bson.MarshalBuffer(bson.M{"a": 1}, buf)
 	c.Assert(err, IsNil)
 	c.Assert(data, DeepEquals, buf[:len(data)])
+}
+
+func (s *S) TestPtrInline(c *C) {
+	cases := []struct {
+		In  interface{}
+		Out bson.M
+	}{
+		{
+			In:  inlinePtrStruct{A: 1, MStruct: &MStruct{M: 3}},
+			Out: bson.M{"a": 1, "m": 3},
+		},
+		{ // go deeper
+			In:  inlinePtrPtrStruct{B: 10, inlinePtrStruct: &inlinePtrStruct{A: 20, MStruct: &MStruct{M: 30}}},
+			Out: bson.M{"b": 10, "a": 20, "m": 30},
+		},
+		{
+			// nil embed struct
+			In:  &inlinePtrStruct{A: 3},
+			Out: bson.M{"a": 3},
+		},
+		{
+			// nil embed struct
+			In:  &inlinePtrPtrStruct{B: 5},
+			Out: bson.M{"b": 5},
+		},
+	}
+
+	for _, cs := range cases {
+		data, err := bson.Marshal(cs.In)
+		c.Assert(err, IsNil)
+		var dataBSON bson.M
+		err = bson.Unmarshal(data, &dataBSON)
+		c.Assert(err, IsNil)
+
+		c.Assert(dataBSON, DeepEquals, cs.Out)
+	}
 }
 
 // --------------------------------------------------------------------------
@@ -713,8 +751,6 @@ var marshalErrorItems = []testItemType{
 		"Attempted to marshal empty Raw document"},
 	{bson.M{"w": bson.Raw{Kind: 0x3, Data: []byte{}}},
 		"Attempted to marshal empty Raw document"},
-	{&inlineCantPtr{&struct{ A, B int }{1, 2}},
-		"Option ,inline needs a struct value or map field"},
 	{&inlineDupName{1, struct{ A, B int }{2, 3}},
 		"Duplicated key 'a' in struct bson_test.inlineDupName"},
 	{&inlineDupMap{},
@@ -1171,8 +1207,19 @@ type inlineBadKeyMap struct {
 	M map[int]int `bson:",inline"`
 }
 type inlineUnexported struct {
-	M map[string]interface{} `bson:",inline"`
-	unexported               `bson:",inline"`
+	M          map[string]interface{} `bson:",inline"`
+	unexported `bson:",inline"`
+}
+type MStruct struct {
+	M int `bson:"m,omitempty"`
+}
+type inlinePtrStruct struct {
+	A        int
+	*MStruct `bson:",inline"`
+}
+type inlinePtrPtrStruct struct {
+	B                int
+	*inlinePtrStruct `bson:",inline"`
 }
 type unexported struct {
 	A int
@@ -1229,11 +1276,11 @@ func (s ifaceSlice) GetBSON() (interface{}, error) {
 
 type (
 	MyString string
-	MyBytes []byte
-	MyBool bool
-	MyD []bson.DocElem
-	MyRawD []bson.RawDocElem
-	MyM map[string]interface{}
+	MyBytes  []byte
+	MyBool   bool
+	MyD      []bson.DocElem
+	MyRawD   []bson.RawDocElem
+	MyM      map[string]interface{}
 )
 
 var (
@@ -1886,5 +1933,107 @@ func (s *S) BenchmarkUnmarshalRaw(c *C) {
 func (s *S) BenchmarkNewObjectId(c *C) {
 	for i := 0; i < c.N; i++ {
 		bson.NewObjectId()
+	}
+}
+
+func (s *S) TestMarshalRespectNil(c *C) {
+	type T struct {
+		Slice    []int
+		SlicePtr *[]int
+		Ptr      *int
+		Map      map[string]interface{}
+		MapPtr   *map[string]interface{}
+	}
+
+	bson.SetRespectNilValues(true)
+	defer bson.SetRespectNilValues(false)
+
+	testStruct1 := T{}
+
+	c.Assert(testStruct1.Slice, IsNil)
+	c.Assert(testStruct1.SlicePtr, IsNil)
+	c.Assert(testStruct1.Map, IsNil)
+	c.Assert(testStruct1.MapPtr, IsNil)
+	c.Assert(testStruct1.Ptr, IsNil)
+
+	b, _ := bson.Marshal(testStruct1)
+
+	testStruct2 := T{}
+
+	bson.Unmarshal(b, &testStruct2)
+
+	c.Assert(testStruct2.Slice, IsNil)
+	c.Assert(testStruct2.SlicePtr, IsNil)
+	c.Assert(testStruct2.Map, IsNil)
+	c.Assert(testStruct2.MapPtr, IsNil)
+	c.Assert(testStruct2.Ptr, IsNil)
+
+	testStruct1 = T{
+		Slice:    []int{},
+		SlicePtr: &[]int{},
+		Map:      map[string]interface{}{},
+		MapPtr:   &map[string]interface{}{},
+	}
+
+	c.Assert(testStruct1.Slice, NotNil)
+	c.Assert(testStruct1.SlicePtr, NotNil)
+	c.Assert(testStruct1.Map, NotNil)
+	c.Assert(testStruct1.MapPtr, NotNil)
+
+	b, _ = bson.Marshal(testStruct1)
+
+	testStruct2 = T{}
+
+	bson.Unmarshal(b, &testStruct2)
+
+	c.Assert(testStruct2.Slice, NotNil)
+	c.Assert(testStruct2.SlicePtr, NotNil)
+	c.Assert(testStruct2.Map, NotNil)
+	c.Assert(testStruct2.MapPtr, NotNil)
+}
+
+func (s *S) TestMongoTimestampTime(c *C) {
+	t := time.Now()
+	ts, err := bson.NewMongoTimestamp(t, 123)
+	c.Assert(err, IsNil)
+	c.Assert(ts.Time().Unix(), Equals, t.Unix())
+}
+
+func (s *S) TestMongoTimestampCounter(c *C) {
+	rnd := rand.Uint32()
+	ts, err := bson.NewMongoTimestamp(time.Now(), rnd)
+	c.Assert(err, IsNil)
+	c.Assert(ts.Counter(), Equals, rnd)
+}
+
+func (s *S) TestMongoTimestampError(c *C) {
+	t := time.Date(1969, time.December, 31, 23, 59, 59, 999, time.UTC)
+	ts, err := bson.NewMongoTimestamp(t, 321)
+	c.Assert(int64(ts), Equals, int64(-1))
+	c.Assert(err, ErrorMatches, "invalid value for time")
+}
+
+func ExampleNewMongoTimestamp() {
+
+	var counter uint32 = 1
+	var t time.Time
+
+	for i := 1; i <= 3; i++ {
+
+		if c := time.Now(); t.Unix() == c.Unix() {
+			counter++
+		} else {
+			t = c
+			counter = 1
+		}
+
+		ts, err := bson.NewMongoTimestamp(t, counter)
+		if err != nil {
+			fmt.Printf("NewMongoTimestamp error: %v", err)
+		} else {
+			fmt.Printf("NewMongoTimestamp encoded timestamp: %d\n", ts)
+		}
+
+		time.Sleep(500 * time.Millisecond)
 	}
 }

--- a/bson/compatibility.go
+++ b/bson/compatibility.go
@@ -1,7 +1,8 @@
 package bson
 
-// Current state of the JSON tag fallback option. 
+// Current state of the JSON tag fallback option.
 var useJSONTagFallback = false
+var useRespectNilValues = false
 
 // SetJSONTagFallback enables or disables the JSON-tag fallback for structure tagging. When this is enabled, structures
 // without BSON tags on a field will fall-back to using the JSON tag (if present).
@@ -13,4 +14,16 @@ func SetJSONTagFallback(state bool) {
 // for more information.
 func JSONTagFallbackState() bool {
 	return useJSONTagFallback
+}
+
+// SetRespectNilValues enables or disables serializing nil slices or maps to `null` values.
+// In other words it enables `encoding/json` compatible behaviour.
+func SetRespectNilValues(state bool) {
+	useRespectNilValues = state
+}
+
+// RespectNilValuesState returns the current status of the JSON nil slices and maps fallback compatibility option.
+// See SetRespectNilValues for more information.
+func RespectNilValuesState() bool {
+	return useRespectNilValues
 }

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -229,13 +229,46 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.Inline == nil {
 			value = v.Field(info.Num)
 		} else {
-			value = v.FieldByIndex(info.Inline)
+			// as pointers to struct are allowed here,
+			// there is no guarantee that pointer won't be nil.
+			//
+			// It is expected allowed behaviour
+			// so info.Inline MAY consist index to a nil pointer
+			// and that is why we safely call v.FieldByIndex and just continue on panic
+			field, errField := safeFieldByIndex(v, info.Inline)
+			if errField != nil {
+				continue
+			}
+
+			value = field
 		}
 		if info.OmitEmpty && isZero(value) {
 			continue
 		}
+		if useRespectNilValues &&
+			(value.Kind() == reflect.Slice || value.Kind() == reflect.Map) &&
+			value.IsNil() {
+			e.addElem(info.Key, reflect.ValueOf(nil), info.MinSize)
+			continue
+		}
 		e.addElem(info.Key, value, info.MinSize)
 	}
+}
+
+func safeFieldByIndex(v reflect.Value, index []int) (result reflect.Value, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch r := recovered.(type) {
+			case string:
+				err = fmt.Errorf("%s", r)
+			case error:
+				err = r
+			}
+		}
+	}()
+
+	result = v.FieldByIndex(index)
+	return
 }
 
 func isZero(v reflect.Value) bool {

--- a/cluster.go
+++ b/cluster.go
@@ -48,34 +48,26 @@ import (
 
 type mongoCluster struct {
 	sync.RWMutex
-	serverSynced  sync.Cond
-	userSeeds     []string
-	dynaSeeds     []string
-	servers       mongoServers
-	masters       mongoServers
-	references    int
-	syncing       bool
-	direct        bool
-	failFast      bool
-	syncCount     uint
-	setName       string
-	cachedIndex   map[string]bool
-	sync          chan bool
-	dial          dialer
-	appName       string
-	minPoolSize   int
-	maxIdleTimeMS int
+	serverSynced sync.Cond
+	userSeeds    []string
+	dynaSeeds    []string
+	servers      mongoServers
+	masters      mongoServers
+	references   int
+	syncing      bool
+	syncCount    uint
+	cachedIndex  map[string]bool
+	sync         chan bool
+	dial         dialer
+	dialInfo     *DialInfo
 }
 
-func newCluster(userSeeds []string, direct, failFast bool, dial dialer, setName string, appName string) *mongoCluster {
+func newCluster(userSeeds []string, info *DialInfo) *mongoCluster {
 	cluster := &mongoCluster{
 		userSeeds:  userSeeds,
 		references: 1,
-		direct:     direct,
-		failFast:   failFast,
-		dial:       dial,
-		setName:    setName,
-		appName:    appName,
+		dial:       dialer{info.Dial, info.DialServer},
+		dialInfo:   info,
 	}
 	cluster.serverSynced.L = cluster.RWMutex.RLocker()
 	cluster.sync = make(chan bool, 1)
@@ -147,7 +139,7 @@ type isMasterResult struct {
 
 func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResult) error {
 	// Monotonic let's it talk to a slave and still hold the socket.
-	session := newSession(Monotonic, cluster, 10*time.Second)
+	session := newSession(Monotonic, cluster, cluster.dialInfo)
 	session.setSocket(socket)
 
 	var cmd = bson.D{{Name: "isMaster", Value: 1}}
@@ -171,8 +163,8 @@ func (cluster *mongoCluster) isMaster(socket *mongoSocket, result *isMasterResul
 		}
 
 		// Include the application name if set
-		if cluster.appName != "" {
-			meta["application"] = bson.M{"name": cluster.appName}
+		if cluster.dialInfo.AppName != "" {
+			meta["application"] = bson.M{"name": cluster.dialInfo.AppName}
 		}
 
 		cmd = append(cmd, bson.DocElem{
@@ -190,19 +182,7 @@ type possibleTimeout interface {
 	Timeout() bool
 }
 
-var syncSocketTimeout = 5 * time.Second
-
 func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerInfo, hosts []string, err error) {
-	var syncTimeout time.Duration
-	if raceDetector {
-		// This variable is only ever touched by tests.
-		globalMutex.Lock()
-		syncTimeout = syncSocketTimeout
-		globalMutex.Unlock()
-	} else {
-		syncTimeout = syncSocketTimeout
-	}
-
 	addr := server.Addr
 	log("SYNC Processing ", addr, "...")
 
@@ -210,7 +190,7 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 	var result isMasterResult
 	var tryerr error
 	for retry := 0; ; retry++ {
-		if retry == 3 || retry == 1 && cluster.failFast {
+		if retry == 3 || retry == 1 && cluster.dialInfo.FailFast {
 			return nil, nil, tryerr
 		}
 		if retry > 0 {
@@ -222,16 +202,22 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 			time.Sleep(syncShortDelay)
 		}
 
-		// It's not clear what would be a good timeout here. Is it
-		// better to wait longer or to retry?
-		socket, _, err := server.AcquireSocket(0, syncTimeout)
+		// Don't ever hit the pool limit for syncing
+		config := cluster.dialInfo.Copy()
+		config.PoolLimit = 0
+
+		socket, _, err := server.AcquireSocket(config)
 		if err != nil {
 			tryerr = err
 			logf("SYNC Failed to get socket to %s: %v", addr, err)
 			continue
 		}
 		err = cluster.isMaster(socket, &result)
+
+		// Restore the correct dial config before returning it to the pool
+		socket.dialInfo = cluster.dialInfo
 		socket.Release()
+
 		if err != nil {
 			tryerr = err
 			logf("SYNC Command 'ismaster' to %s failed: %v", addr, err)
@@ -241,9 +227,9 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 		break
 	}
 
-	if cluster.setName != "" && result.SetName != cluster.setName {
-		logf("SYNC Server %s is not a member of replica set %q", addr, cluster.setName)
-		return nil, nil, fmt.Errorf("server %s is not a member of replica set %q", addr, cluster.setName)
+	if cluster.dialInfo.ReplicaSetName != "" && result.SetName != cluster.dialInfo.ReplicaSetName {
+		logf("SYNC Server %s is not a member of replica set %q", addr, cluster.dialInfo.ReplicaSetName)
+		return nil, nil, fmt.Errorf("server %s is not a member of replica set %q", addr, cluster.dialInfo.ReplicaSetName)
 	}
 
 	if result.IsMaster {
@@ -255,7 +241,7 @@ func (cluster *mongoCluster) syncServer(server *mongoServer) (info *mongoServerI
 		}
 	} else if result.Secondary {
 		debugf("SYNC %s is a slave.", addr)
-	} else if cluster.direct {
+	} else if cluster.dialInfo.Direct {
 		logf("SYNC %s in unknown state. Pretending it's a slave due to direct connection.", addr)
 	} else {
 		logf("SYNC %s is neither a master nor a slave.", addr)
@@ -386,7 +372,7 @@ func (cluster *mongoCluster) syncServersLoop() {
 			break
 		}
 		cluster.references++ // Keep alive while syncing.
-		direct := cluster.direct
+		direct := cluster.dialInfo.Direct
 		cluster.Unlock()
 
 		cluster.syncServersIteration(direct)
@@ -401,7 +387,7 @@ func (cluster *mongoCluster) syncServersLoop() {
 
 		// Hold off before allowing another sync. No point in
 		// burning CPU looking for down servers.
-		if !cluster.failFast {
+		if !cluster.dialInfo.FailFast {
 			time.Sleep(syncShortDelay)
 		}
 
@@ -439,13 +425,11 @@ func (cluster *mongoCluster) syncServersLoop() {
 func (cluster *mongoCluster) server(addr string, tcpaddr *net.TCPAddr) *mongoServer {
 	cluster.RLock()
 	server := cluster.servers.Search(tcpaddr.String())
-	minPoolSize := cluster.minPoolSize
-	maxIdleTimeMS := cluster.maxIdleTimeMS
 	cluster.RUnlock()
 	if server != nil {
 		return server
 	}
-	return newServer(addr, tcpaddr, cluster.sync, cluster.dial, minPoolSize, maxIdleTimeMS)
+	return newServer(addr, tcpaddr, cluster.sync, cluster.dial, cluster.dialInfo)
 }
 
 func resolveAddr(addr string) (*net.TCPAddr, error) {
@@ -614,19 +598,10 @@ func (cluster *mongoCluster) syncServersIteration(direct bool) {
 	cluster.Unlock()
 }
 
-// AcquireSocket returns a socket to a server in the cluster.  If slaveOk is
-// true, it will attempt to return a socket to a slave server.  If it is
-// false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocket(mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int) (s *mongoSocket, err error) {
-	return cluster.AcquireSocketWithPoolTimeout(mode, slaveOk, syncTimeout, socketTimeout, serverTags, poolLimit, 0)
-}
-
 // AcquireSocketWithPoolTimeout returns a socket to a server in the cluster.  If slaveOk is
 // true, it will attempt to return a socket to a slave server.  If it is
 // false, the socket will necessarily be to a master server.
-func (cluster *mongoCluster) AcquireSocketWithPoolTimeout(
-	mode Mode, slaveOk bool, syncTimeout time.Duration, socketTimeout time.Duration, serverTags []bson.D, poolLimit int, poolTimeout time.Duration,
-) (s *mongoSocket, err error) {
+func (cluster *mongoCluster) AcquireSocketWithPoolTimeout(mode Mode, slaveOk bool, syncTimeout time.Duration, serverTags []bson.D, info *DialInfo) (s *mongoSocket, err error) {
 	var started time.Time
 	var syncCount uint
 	for {
@@ -645,7 +620,7 @@ func (cluster *mongoCluster) AcquireSocketWithPoolTimeout(
 				// Initialize after fast path above.
 				started = time.Now()
 				syncCount = cluster.syncCount
-			} else if syncTimeout != 0 && started.Before(time.Now().Add(-syncTimeout)) || cluster.failFast && cluster.syncCount != syncCount {
+			} else if syncTimeout != 0 && started.Before(time.Now().Add(-syncTimeout)) || cluster.dialInfo.FailFast && cluster.syncCount != syncCount {
 				cluster.RUnlock()
 				return nil, errors.New("no reachable servers")
 			}
@@ -670,7 +645,7 @@ func (cluster *mongoCluster) AcquireSocketWithPoolTimeout(
 			continue
 		}
 
-		s, abended, err := server.AcquireSocketWithBlocking(poolLimit, socketTimeout, poolTimeout)
+		s, abended, err := server.AcquireSocketWithBlocking(info)
 		if err == errPoolTimeout {
 			// No need to remove servers from the topology if acquiring a socket fails for this reason.
 			return nil, err

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1055,8 +1055,6 @@ func (s *S) TestSocketTimeoutOnDial(c *C) {
 
 	timeout := 1 * time.Second
 
-	defer mgo.HackSyncSocketTimeout(timeout)()
-
 	s.Freeze("localhost:40001")
 
 	started := time.Now()

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -70,7 +71,7 @@ func (dbs *DBServer) start() {
 	err = dbs.server.Start()
 	if err != nil {
 		// print error to facilitate troubleshooting as the panic will be caught in a panic handler
-		fmt.Fprintf(os.Stderr, "mongod failed to start: %v\n",err)
+		fmt.Fprintf(os.Stderr, "mongod failed to start: %v\n", err)
 		panic(err)
 	}
 	dbs.tomb.Go(dbs.monitor)
@@ -113,7 +114,12 @@ func (dbs *DBServer) Stop() {
 	}
 	if dbs.server != nil {
 		dbs.tomb.Kill(nil)
-		dbs.server.Process.Signal(os.Interrupt)
+		// Windows doesn't support Interrupt
+		if runtime.GOOS == "windows" {
+			dbs.server.Process.Signal(os.Kill)
+		} else {
+			dbs.server.Process.Signal(os.Interrupt)
+		}
 		select {
 		case <-dbs.tomb.Dead():
 		case <-time.After(5 * time.Second):

--- a/example_test.go
+++ b/example_test.go
@@ -137,7 +137,21 @@ func ExampleSession_concurrency() {
 
 func ExampleDial_usingSSL() {
 	// To connect via TLS/SSL (enforced for MongoDB Atlas for example) requires
-	// configuring the dialer to use a TLS connection:
+	// to set the ssl query param to true.
+	url := "mongodb://localhost:40003?ssl=true"
+
+	session, err := Dial(url)
+	if err != nil {
+		panic(err)
+	}
+
+	// Use session as normal
+	session.Close()
+}
+
+func ExampleDial_tlsConfig() {
+	// You can define a custom tlsConfig, this one enables TLS, like if you have
+	// ssl=true in the connection string.
 	url := "mongodb://localhost:40003"
 
 	tlsConfig := &tls.Config{

--- a/export_test.go
+++ b/export_test.go
@@ -19,20 +19,6 @@ func HackPingDelay(newDelay time.Duration) (restore func()) {
 	return
 }
 
-func HackSyncSocketTimeout(newTimeout time.Duration) (restore func()) {
-	globalMutex.Lock()
-	defer globalMutex.Unlock()
-
-	oldTimeout := syncSocketTimeout
-	restore = func() {
-		globalMutex.Lock()
-		syncSocketTimeout = oldTimeout
-		globalMutex.Unlock()
-	}
-	syncSocketTimeout = newTimeout
-	return
-}
-
 func (s *Session) Cluster() *mongoCluster {
 	return s.cluster()
 }

--- a/internal/sasl/sasl.go
+++ b/internal/sasl/sasl.go
@@ -127,6 +127,7 @@ func (ss *saslSession) Step(serverData []byte) (clientData []byte, done bool, er
 	if rc == C.SASL_CONTINUE {
 		return clientData, false, nil
 	}
+
 	return nil, false, saslError(rc, ss.conn, "cannot establish SASL session")
 }
 

--- a/internal/scram/scram.go
+++ b/internal/scram/scram.go
@@ -91,7 +91,7 @@ func NewClient(newHash func() hash.Hash, user, pass string) *Client {
 // Out returns the data to be sent to the server in the current step.
 func (c *Client) Out() []byte {
 	if c.out.Len() == 0 {
-		return nil
+		return []byte{}
 	}
 	return c.out.Bytes()
 }

--- a/server.go
+++ b/server.go
@@ -67,9 +67,8 @@ type mongoServer struct {
 	pingCount     uint32
 	closed        bool
 	abended       bool
-	minPoolSize   int
-	maxIdleTimeMS int
 	poolWaiter    *sync.Cond
+	dialInfo      *DialInfo
 }
 
 type dialer struct {
@@ -91,21 +90,20 @@ type mongoServerInfo struct {
 
 var defaultServerInfo mongoServerInfo
 
-func newServer(addr string, tcpaddr *net.TCPAddr, syncChan chan bool, dial dialer, minPoolSize, maxIdleTimeMS int) *mongoServer {
+func newServer(addr string, tcpaddr *net.TCPAddr, syncChan chan bool, dial dialer, info *DialInfo) *mongoServer {
 	server := &mongoServer{
-		Addr:          addr,
-		ResolvedAddr:  tcpaddr.String(),
-		tcpaddr:       tcpaddr,
-		sync:          syncChan,
-		dial:          dial,
-		info:          &defaultServerInfo,
-		pingValue:     time.Hour, // Push it back before an actual ping.
-		minPoolSize:   minPoolSize,
-		maxIdleTimeMS: maxIdleTimeMS,
+		Addr:         addr,
+		ResolvedAddr: tcpaddr.String(),
+		tcpaddr:      tcpaddr,
+		sync:         syncChan,
+		dial:         dial,
+		info:         &defaultServerInfo,
+		pingValue:    time.Hour, // Push it back before an actual ping.
+		dialInfo:     info,
 	}
 	server.poolWaiter = sync.NewCond(server)
 	go server.pinger(true)
-	if maxIdleTimeMS != 0 {
+	if info.MaxIdleTimeMS != 0 {
 		go server.poolShrinker()
 	}
 	return server
@@ -123,22 +121,18 @@ var errServerClosed = errors.New("server was closed")
 // If the poolLimit argument is greater than zero and the number of sockets in
 // use in this server is greater than the provided limit, errPoolLimit is
 // returned.
-func (server *mongoServer) AcquireSocket(poolLimit int, timeout time.Duration) (socket *mongoSocket, abended bool, err error) {
-	return server.acquireSocketInternal(poolLimit, timeout, false, 0*time.Millisecond)
+func (server *mongoServer) AcquireSocket(info *DialInfo) (socket *mongoSocket, abended bool, err error) {
+	return server.acquireSocketInternal(info, false)
 }
 
 // AcquireSocketWithBlocking wraps AcquireSocket, but if a socket is not available, it will _not_
 // return errPoolLimit. Instead, it will block waiting for a socket to become available. If poolTimeout
 // should elapse before a socket is available, it will return errPoolTimeout.
-func (server *mongoServer) AcquireSocketWithBlocking(
-	poolLimit int, socketTimeout time.Duration, poolTimeout time.Duration,
-) (socket *mongoSocket, abended bool, err error) {
-	return server.acquireSocketInternal(poolLimit, socketTimeout, true, poolTimeout)
+func (server *mongoServer) AcquireSocketWithBlocking(info *DialInfo) (socket *mongoSocket, abended bool, err error) {
+	return server.acquireSocketInternal(info, true)
 }
 
-func (server *mongoServer) acquireSocketInternal(
-	poolLimit int, timeout time.Duration, shouldBlock bool, poolTimeout time.Duration,
-) (socket *mongoSocket, abended bool, err error) {
+func (server *mongoServer) acquireSocketInternal(info *DialInfo, shouldBlock bool) (socket *mongoSocket, abended bool, err error) {
 	for {
 		server.Lock()
 		abended = server.abended
@@ -146,7 +140,7 @@ func (server *mongoServer) acquireSocketInternal(
 			server.Unlock()
 			return nil, abended, errServerClosed
 		}
-		if poolLimit > 0 {
+		if info.PoolLimit > 0 {
 			if shouldBlock {
 				// Beautiful. Golang conditions don't have a WaitWithTimeout, so I've implemented the timeout
 				// with a wait + broadcast. The broadcast will cause the loop here to re-check the timeout,
@@ -158,11 +152,11 @@ func (server *mongoServer) acquireSocketInternal(
 				// https://github.com/golang/go/issues/16620, since the lock needs to be held in _this_ goroutine.
 				waitDone := make(chan struct{})
 				timeoutHit := false
-				if poolTimeout > 0 {
+				if info.PoolTimeout > 0 {
 					go func() {
 						select {
 						case <-waitDone:
-						case <-time.After(poolTimeout):
+						case <-time.After(info.PoolTimeout):
 							// timeoutHit is part of the wait condition, so needs to be changed under mutex.
 							server.Lock()
 							defer server.Unlock()
@@ -172,7 +166,7 @@ func (server *mongoServer) acquireSocketInternal(
 					}()
 				}
 				timeSpentWaiting := time.Duration(0)
-				for len(server.liveSockets)-len(server.unusedSockets) >= poolLimit && !timeoutHit {
+				for len(server.liveSockets)-len(server.unusedSockets) >= info.PoolLimit && !timeoutHit {
 					// We only count time spent in Wait(), and not time evaluating the entire loop,
 					// so that in the happy non-blocking path where the condition above evaluates true
 					// first time, we record a nice round zero wait time.
@@ -191,7 +185,7 @@ func (server *mongoServer) acquireSocketInternal(
 				// Record that we fetched a connection of of a socket list and how long we spent waiting
 				stats.noticeSocketAcquisition(timeSpentWaiting)
 			} else {
-				if len(server.liveSockets)-len(server.unusedSockets) >= poolLimit {
+				if len(server.liveSockets)-len(server.unusedSockets) >= info.PoolLimit {
 					server.Unlock()
 					return nil, false, errPoolLimit
 				}
@@ -202,15 +196,15 @@ func (server *mongoServer) acquireSocketInternal(
 			socket = server.unusedSockets[n-1]
 			server.unusedSockets[n-1] = nil // Help GC.
 			server.unusedSockets = server.unusedSockets[:n-1]
-			info := server.info
+			serverInfo := server.info
 			server.Unlock()
-			err = socket.InitialAcquire(info, timeout)
+			err = socket.InitialAcquire(serverInfo, info)
 			if err != nil {
 				continue
 			}
 		} else {
 			server.Unlock()
-			socket, err = server.Connect(timeout)
+			socket, err = server.Connect(info)
 			if err == nil {
 				server.Lock()
 				// We've waited for the Connect, see if we got
@@ -231,20 +225,18 @@ func (server *mongoServer) acquireSocketInternal(
 
 // Connect establishes a new connection to the server. This should
 // generally be done through server.AcquireSocket().
-func (server *mongoServer) Connect(timeout time.Duration) (*mongoSocket, error) {
+func (server *mongoServer) Connect(info *DialInfo) (*mongoSocket, error) {
 	server.RLock()
 	master := server.info.Master
 	dial := server.dial
 	server.RUnlock()
 
-	logf("Establishing new connection to %s (timeout=%s)...", server.Addr, timeout)
+	logf("Establishing new connection to %s (timeout=%s)...", server.Addr, info.Timeout)
 	var conn net.Conn
 	var err error
 	switch {
 	case !dial.isSet():
-		// Cannot do this because it lacks timeout support. :-(
-		//conn, err = net.DialTCP("tcp", nil, server.tcpaddr)
-		conn, err = net.DialTimeout("tcp", server.ResolvedAddr, timeout)
+		conn, err = net.DialTimeout("tcp", server.ResolvedAddr, info.Timeout)
 		if tcpconn, ok := conn.(*net.TCPConn); ok {
 			tcpconn.SetKeepAlive(true)
 		} else if err == nil {
@@ -264,7 +256,7 @@ func (server *mongoServer) Connect(timeout time.Duration) (*mongoSocket, error) 
 	logf("Connection to %s established.", server.Addr)
 
 	stats.conn(+1, master)
-	return newSocket(server, conn, timeout), nil
+	return newSocket(server, conn, info), nil
 }
 
 // Close forces closing all sockets that are alive, whether
@@ -407,7 +399,8 @@ func (server *mongoServer) pinger(loop bool) {
 			time.Sleep(delay)
 		}
 		op := op
-		socket, _, err := server.AcquireSocket(0, delay)
+
+		socket, _, err := server.AcquireSocket(server.dialInfo)
 		if err == nil {
 			start := time.Now()
 			_, _ = socket.SimpleQuery(&op)
@@ -448,7 +441,7 @@ func (server *mongoServer) poolShrinker() {
 		}
 		server.Lock()
 		unused := len(server.unusedSockets)
-		if unused < server.minPoolSize {
+		if unused < server.dialInfo.MinPoolSize {
 			server.Unlock()
 			continue
 		}
@@ -457,8 +450,8 @@ func (server *mongoServer) poolShrinker() {
 		reclaimMap := map[*mongoSocket]struct{}{}
 		// Because the acquisition and recycle are done at the tail of array,
 		// the head is always the oldest unused socket.
-		for _, s := range server.unusedSockets[:unused-server.minPoolSize] {
-			if s.lastTimeUsed.Add(time.Duration(server.maxIdleTimeMS) * time.Millisecond).After(now) {
+		for _, s := range server.unusedSockets[:unused-server.dialInfo.MinPoolSize] {
+			if s.lastTimeUsed.Add(time.Duration(server.dialInfo.MaxIdleTimeMS) * time.Millisecond).After(now) {
 				break
 			}
 			end++
@@ -572,7 +565,7 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		if best == nil {
 			best = next
 			best.RLock()
-			if serverTags != nil && !next.info.Mongos && !best.hasTags(serverTags) {
+			if len(serverTags) != 0 && !next.info.Mongos && !best.hasTags(serverTags) {
 				best.RUnlock()
 				best = nil
 			}
@@ -581,7 +574,7 @@ func (servers *mongoServers) BestFit(mode Mode, serverTags []bson.D) *mongoServe
 		next.RLock()
 		swap := false
 		switch {
-		case serverTags != nil && !next.info.Mongos && !next.hasTags(serverTags):
+		case len(serverTags) != 0 && !next.info.Mongos && !next.hasTags(serverTags):
 			// Must have requested tags.
 		case mode == Secondary && next.info.Master && !next.info.Mongos:
 			// Must be a secondary or mongos.

--- a/session_internal_test.go
+++ b/session_internal_test.go
@@ -3,9 +3,11 @@ package mgo
 import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"testing"
+	"time"
+
 	"github.com/globalsign/mgo/bson"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type S struct{}
@@ -61,4 +63,23 @@ func (s *S) TestGetRFC2253NameStringMultiValued(c *C) {
 	}
 
 	c.Assert(getRFC2253NameString(&RDNElements), Equals, "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US")
+}
+
+func (s *S) TestDialTimeouts(c *C) {
+	info := &DialInfo{}
+
+	c.Assert(info.readTimeout(), Equals, time.Duration(0))
+	c.Assert(info.writeTimeout(), Equals, time.Duration(0))
+	c.Assert(info.roundTripTimeout(), Equals, time.Duration(0))
+
+	info.Timeout = 60 * time.Second
+	c.Assert(info.readTimeout(), Equals, 60*time.Second)
+	c.Assert(info.writeTimeout(), Equals, 60*time.Second)
+	c.Assert(info.roundTripTimeout(), Equals, 120*time.Second)
+
+	info.ReadTimeout = time.Second
+	c.Assert(info.readTimeout(), Equals, time.Second)
+
+	info.WriteTimeout = time.Second
+	c.Assert(info.writeTimeout(), Equals, time.Second)
 }

--- a/socket.go
+++ b/socket.go
@@ -42,7 +42,6 @@ type mongoSocket struct {
 	sync.Mutex
 	server         *mongoServer // nil when cached
 	conn           net.Conn
-	timeout        time.Duration
 	addr           string // For debugging only.
 	nextRequestId  uint32
 	replyFuncs     map[uint32]replyFunc
@@ -56,6 +55,8 @@ type mongoSocket struct {
 	closeAfterIdle bool
 	lastTimeUsed   time.Time // for time based idle socket release
 	sendMeta       sync.Once
+
+	dialInfo *DialInfo
 }
 
 type queryOpFlags uint32
@@ -181,15 +182,16 @@ type requestInfo struct {
 	replyFunc replyFunc
 }
 
-func newSocket(server *mongoServer, conn net.Conn, timeout time.Duration) *mongoSocket {
+func newSocket(server *mongoServer, conn net.Conn, info *DialInfo) *mongoSocket {
 	socket := &mongoSocket{
 		conn:       conn,
 		addr:       server.Addr,
 		server:     server,
 		replyFuncs: make(map[uint32]replyFunc),
+		dialInfo:   info,
 	}
 	socket.gotNonce.L = &socket.Mutex
-	if err := socket.InitialAcquire(server.Info(), timeout); err != nil {
+	if err := socket.InitialAcquire(server.Info(), info); err != nil {
 		panic("newSocket: InitialAcquire returned error: " + err.Error())
 	}
 	stats.socketsAlive(+1)
@@ -223,7 +225,7 @@ func (socket *mongoSocket) ServerInfo() *mongoServerInfo {
 // InitialAcquire obtains the first reference to the socket, either
 // right after the connection is made or once a recycled socket is
 // being put back in use.
-func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout time.Duration) error {
+func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, dialInfo *DialInfo) error {
 	socket.Lock()
 	if socket.references > 0 {
 		panic("Socket acquired out of cache with references")
@@ -235,7 +237,7 @@ func (socket *mongoSocket) InitialAcquire(serverInfo *mongoServerInfo, timeout t
 	}
 	socket.references++
 	socket.serverInfo = serverInfo
-	socket.timeout = timeout
+	socket.dialInfo = dialInfo
 	stats.socketsInUse(+1)
 	stats.socketRefs(+1)
 	socket.Unlock()
@@ -288,7 +290,8 @@ func (socket *mongoSocket) Release() {
 // SetTimeout changes the timeout used on socket operations.
 func (socket *mongoSocket) SetTimeout(d time.Duration) {
 	socket.Lock()
-	socket.timeout = d
+	socket.dialInfo.ReadTimeout = d
+	socket.dialInfo.WriteTimeout = d
 	socket.Unlock()
 }
 
@@ -301,24 +304,37 @@ const (
 
 func (socket *mongoSocket) updateDeadline(which deadlineType) {
 	var when time.Time
-	if socket.timeout > 0 {
-		when = time.Now().Add(socket.timeout)
-	}
-	whichstr := ""
+	var whichStr string
 	switch which {
 	case readDeadline | writeDeadline:
-		whichstr = "read/write"
+		if socket.dialInfo.roundTripTimeout() == 0 {
+			return
+		}
+		whichStr = "read/write"
+		when = time.Now().Add(socket.dialInfo.roundTripTimeout())
 		socket.conn.SetDeadline(when)
+
 	case readDeadline:
-		whichstr = "read"
+		if socket.dialInfo.ReadTimeout == zeroDuration {
+			return
+		}
+		whichStr = "read"
+		when = time.Now().Add(socket.dialInfo.ReadTimeout)
 		socket.conn.SetReadDeadline(when)
+
 	case writeDeadline:
-		whichstr = "write"
+		if socket.dialInfo.WriteTimeout == zeroDuration {
+			return
+		}
+		whichStr = "write"
+		when = time.Now().Add(socket.dialInfo.WriteTimeout)
 		socket.conn.SetWriteDeadline(when)
+
 	default:
 		panic("invalid parameter to updateDeadline")
 	}
-	debugf("Socket %p to %s: updated %s deadline to %s ahead (%s)", socket, socket.addr, whichstr, socket.timeout, when)
+
+	debugf("Socket %p to %s: updated %s deadline to %s", socket, socket.addr, whichStr, when)
 }
 
 // Close terminates the socket use.


### PR DESCRIPTION
Includes:

* Collation support for `Count()` queries ([detials](https://github.com/globalsign/mgo/pull/166))
* Support encoding of inline struct references ([details](https://github.com/globalsign/mgo/pull/146))
* Improved windows test harness ([details](https://github.com/globalsign/mgo/pull/158))
* Improved type and nil handling in the BSON codec ([details](https://github.com/globalsign/mgo/pull/147), [more](https://github.com/globalsign/mgo/pull/181))
* Separated network read/write timeouts ([details](https://github.com/globalsign/mgo/pull/161))
* Expanded dial string configuration options ([details](https://github.com/globalsign/mgo/pull/162))
* Implement MongoTimestamp ([details](https://github.com/globalsign/mgo/pull/171))
* Support setting `writeConcern` for `findAndModify` operations ([details](https://github.com/globalsign/mgo/pull/185))
* Add `ssl` to the dial string options ([details](https://github.com/globalsign/mgo/pull/184))

Thanks to:

* @cedric-cordenier
* @DaytonG
* @ddspog
* @gedge
* @jefferickson
* @larrycinnabar
* @Mei-Zhao
* @roobre
* @tbruyelle