### PR TITLE
bind actionPool to Bulk instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _harness
 .vscode
+.idea/


### PR DESCRIPTION
This resolves globalsign/mgo#197 
The variable **actionPool** scope should be with Bulk instance so that we can use different bulk instances safely