### PR TITLE
bson: set slice cap for bytes and raw

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -511,7 +511,7 @@ func (d *decoder) readRaw(kind byte) Raw {
 	d.i += size
 	return Raw{
 		Kind: kind,
-		Data: d.in[d.i-size : d.i],
+		Data: d.in[d.i-size : d.i : d.i],
 	}
 }
 
@@ -1051,5 +1051,5 @@ func (d *decoder) readBytes(length int32) []byte {
 	if d.i < start || d.i > len(d.in) {
 		corrupted()
 	}
-	return d.in[start : start+int(length)]
+	return d.in[start : start+int(length) : start+int(length)]
 }

--- a/bson/decode_test.go
+++ b/bson/decode_test.go
@@ -1,0 +1,31 @@
+package bson
+
+import "testing"
+
+func TestDecodeRawCap(t *testing.T) {
+	var v struct{ R *Raw }
+	marshalUnmarshal(t, struct {
+		R int
+	}{R: 1}, &v)
+	if len(v.R.Data) != cap(v.R.Data) {
+		t.Fatalf("expected len == cap, got len = %d and cap = %d", len(v.R.Data), cap(v.R.Data))
+	}
+}
+
+func TestDecodeBytesCap(t *testing.T) {
+	v := struct{ B []byte }{[]byte{1}}
+	marshalUnmarshal(t, v, &v)
+	if len(v.B) != cap(v.B) {
+		t.Fatalf("expected len == cap, got len = %d and cap = %d", len(v.B), cap(v.B))
+	}
+}
+
+func marshalUnmarshal(t *testing.T, in, out interface{}) {
+	data, err := Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Unmarshal(data, out); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This prevents later `append`s from damaging the data in the buffer.