### PR TITLE
Add 3.6+ user authenticationRestrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * Support setting `writeConcern` for `findAndModify` operations ([details](https://github.com/globalsign/mgo/pull/185))
 * Add `ssl` to the dial string options ([details](https://github.com/globalsign/mgo/pull/184))
 * Support connecting via Unix sockets ([details](https://github.com/globalsign/mgo/pull/129))
-* Support MongoDB User authenticationRestrictions [details](https://github.com/globalsign/mgo/pull/229/files)
+* Support MongoDB User authenticationRestrictions ([details](https://github.com/globalsign/mgo/pull/229))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * Support setting `writeConcern` for `findAndModify` operations ([details](https://github.com/globalsign/mgo/pull/185))
 * Add `ssl` to the dial string options ([details](https://github.com/globalsign/mgo/pull/184))
 * Support connecting via Unix sockets ([details](https://github.com/globalsign/mgo/pull/129))
-* Support authenticationRestrictions in MongoDB Users [details](https://github.com/globalsign/mgo/pull/229/files)
+* Support MongoDB User authenticationRestrictions [details](https://github.com/globalsign/mgo/pull/229/files)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implement
 * Support setting `writeConcern` for `findAndModify` operations ([details](https://github.com/globalsign/mgo/pull/185))
 * Add `ssl` to the dial string options ([details](https://github.com/globalsign/mgo/pull/184))
 * Support connecting via Unix sockets ([details](https://github.com/globalsign/mgo/pull/129))
-
+* Support authenticationRestrictions in MongoDB Users [details](https://github.com/globalsign/mgo/pull/229/files)
 
 ---
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -377,7 +377,7 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 	c.Assert(err, IsNil)
 
 	// Dial again to ensure the authentication restriction blocks the connection
-	_, err := mgo.Dial("mongodb://authRestrictionUser:123456@127.0.0.1:40002/admin")
+	_, err = mgo.Dial("mongodb://authRestrictionUser:123456@127.0.0.1:40002/admin")
 	c.Assert(err, ErrorMatches, ".*Authentication failed.")
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -389,8 +389,10 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 
 	// Dial again to ensure the authentication restriction blocks the connections.
 	denySession, err := mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
+	if denySession != nil {
+		denySession.Close()
+	}
 	c.Assert(err, ErrorMatches, ".*Authentication failed.")
-	defer denySession.Close()
 }
 
 func (s *S) TestAuthAddUser(c *C) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -343,7 +343,7 @@ func (s *S) TestAuthUpsertUserUpdates(c *C) {
 
 func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 	if !s.versionAtLeast(3, 6) {
-		c.Skip("UpsertUser only works on 3.6+")
+		c.Skip("UpsertUser with user 'authenticationRestrictions' only works on 3.6+")
 	}
 	session, err := mgo.Dial("localhost:40002")
 	c.Assert(err, IsNil)

--- a/auth_test.go
+++ b/auth_test.go
@@ -352,8 +352,8 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 	admindb := session.DB("admin")
 	err = admindb.Login("root", "rapadura")
 
-	allowUser := &mgo.User{
-		Username: "allowUser",
+	user := &mgo.User{
+		Username: "authRestrictionUser",
 		Password: "123456",
 		Roles:    []mgo.Role{mgo.RoleReadWrite},
 		AuthenticationRestrictions: []mgo.AuthenticationRestriction{
@@ -363,35 +363,21 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 			},
 		},
 	}
-	err = admindb.UpsertUser(allowUser)
+	err = admindb.UpsertUser(user)
 	c.Assert(err, IsNil)
 
-	// Dial again to ensure the positive authentication restriction allows the connection.
-	allowSession, err := mgo.Dial("mongodb://allowUser:123456@127.0.0.1:40002/admin")
+	// Dial again to ensure the positive authentication restriction allows the connection
+	allowSession, err := mgo.Dial("mongodb://authRestrictionUser:123456@127.0.0.1:40002/admin")
 	c.Assert(err, IsNil)
 	c.Assert(allowSession.Ping(), IsNil)
 	defer allowSession.Close()
 
-	// this user should fail authentication restrictions
-	denyUser := &mgo.User{
-		Username: "denyUser",
-		Password: "123456",
-		Roles:    []mgo.Role{mgo.RoleReadWrite},
-		AuthenticationRestrictions: []mgo.AuthenticationRestriction{
-			{
-				ClientSource:  []string{"1.2.3.4"},
-				ServerAddress: []string{"4.3.2.1"},
-			},
-		},
-	}
-	err = admindb.UpsertUser(denyUser)
+	user.AuthenticationRestrictions.ClientSource = "4.3.2.1"
+	err = admindb.UpsertUser(user)
 	c.Assert(err, IsNil)
 
-	// Dial again to ensure the authentication restriction blocks the connections.
-	denySession, err := mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
-	if denySession != nil {
-		denySession.Close()
-	}
+	// Dial again to ensure the authentication restriction blocks the connection
+	_, err := mgo.Dial("mongodb://authRestrictionUser:123456@127.0.0.1:40002/admin")
 	c.Assert(err, ErrorMatches, ".*Authentication failed.")
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -389,7 +389,7 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 
 	// Dial again to ensure the authentication restriction blocks the connections.
 	denySession, err := mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
-	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	c.Assert(err, ErrorMatches, ".*Authentication failed.")
 	defer denySession.Close()
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -341,6 +341,58 @@ func (s *S) TestAuthUpsertUserUpdates(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
+	if !s.versionAtLeast(3, 6) {
+		c.Skip("UpsertUser only works on 3.6+")
+	}
+	session, err := mgo.Dial("localhost:40002")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	admindb := session.DB("admin")
+	err = admindb.Login("root", "rapadura")
+
+	allowUser := &mgo.User{
+		Username: "allowUser",
+		Password: "123456",
+		Roles:    []mgo.Role{mgo.RoleReadWrite},
+		AuthenticationRestrictions: []mgo.AuthenticationRestriction{
+			{
+				ClientSource:  []string{"127.0.0.1"},
+				ServerAddress: []string{"127.0.0.1"},
+			},
+		},
+	}
+	err = admindb.UpsertUser(allowUser)
+	c.Assert(err, IsNil)
+
+	// Dial again to ensure the positive authentication restriction allows the connection.
+	allowSession, err := mgo.Dial("mongodb://allowUser:123456@127.0.0.1:40002/admin")
+	c.Assert(err, IsNil)
+	c.Assert(allowSession.Ping(), IsNil)
+	defer allowSession.Close()
+
+	// this user should fail authentication restrictions
+	denyUser := &mgo.User{
+		Username: "denyUser",
+		Password: "123456",
+		Roles:    []mgo.Role{mgo.RoleReadWrite},
+		AuthenticationRestrictions: []mgo.AuthenticationRestriction{
+			{
+				ClientSource:  []string{"1.2.3.4"},
+				ServerAddress: []string{"4.3.2.1"},
+			},
+		},
+	}
+	err = admindb.UpsertUser(denyUser)
+	c.Assert(err, IsNil)
+
+	// Dial again to ensure the authentication restriction blocks the connections.
+	denySession, err := mgo.Dial("mongodb://allowUser:123456@127.0.0.1:40002/admin")
+	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
+	defer denySession.Close()
+}
+
 func (s *S) TestAuthAddUser(c *C) {
 	session, err := mgo.Dial("localhost:40002")
 	c.Assert(err, IsNil)

--- a/auth_test.go
+++ b/auth_test.go
@@ -388,7 +388,7 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 	c.Assert(err, IsNil)
 
 	// Dial again to ensure the authentication restriction blocks the connections.
-	denySession, err := mgo.Dial("mongodb://allowUser:123456@127.0.0.1:40002/admin")
+	denySession, err := mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
 	c.Assert(err, ErrorMatches, "unauthorized|not authorized .*")
 	defer denySession.Close()
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -388,7 +388,7 @@ func (s *S) TestAuthUpsertUserAuthenticationRestrictions(c *C) {
 	c.Assert(err, IsNil)
 
 	// Dial again to ensure the authentication restriction blocks the connections.
-	_, err := mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
+	_, err = mgo.Dial("mongodb://denyUser:123456@127.0.0.1:40002/admin")
 	c.Assert(err, ErrorMatches, ".*Authentication failed.")
 }
 

--- a/session.go
+++ b/session.go
@@ -1169,8 +1169,8 @@ func (s *Session) LogoutAll() {
 }
 
 // AuthenticationRestriction represents an authentication restriction
-// for a MongoDB User. Authentication Restrictions is a new feature
-// since version 3.6
+// for a MongoDB User. Authentication Restrictions was added in version
+// 3.6.
 type AuthenticationRestriction struct {
 	ClientSource  []string `bson:"clientSource,omitempty"`
 	ServerAddress []string `bson:"serverAddress,omitempty"`

--- a/session.go
+++ b/session.go
@@ -1171,6 +1171,11 @@ func (s *Session) LogoutAll() {
 // AuthenticationRestriction represents an authentication restriction
 // for a MongoDB User. Authentication Restrictions was added in version
 // 3.6.
+//
+// Relevant documentation:
+//
+//     https://docs.mongodb.com/manual/reference/method/db.createUser/#authentication-restrictions
+//
 type AuthenticationRestriction struct {
 	ClientSource  []string `bson:"clientSource,omitempty"`
 	ServerAddress []string `bson:"serverAddress,omitempty"`

--- a/session.go
+++ b/session.go
@@ -1227,8 +1227,8 @@ type User struct {
 	// addresses and CIDR ranges from which the user is allowed to connect
 	// to the server or from which the server can accept users.
 	//
-	// WARNING Authentication Restrictions is only supported in version 3.6
-	// and above.
+	// WARNING: Authentication Restrictions is only supported in version
+	// 3.6 and above.
 	AuthenticationRestrictions []AuthenticationRestriction `bson:"authenticationRestrictions,omitempty"`
 }
 

--- a/session.go
+++ b/session.go
@@ -1217,7 +1217,10 @@ type User struct {
 	// and is now obsolete.
 	UserSource string `bson:"userSource,omitempty"`
 
-	// AuthenticationRestrictions ...
+	// AuthenticationRestrictions represents authentication restrictions
+	// the server enforces on the created user. Specifies a list of IP
+	// addresses and CIDR ranges from which the user is allowed to connect
+	// to the server or from which the server can accept users.
 	AuthenticationRestrictions []AuthenticationRestriction `bson:"authenticationRestrictions,omitempty"`
 }
 

--- a/session.go
+++ b/session.go
@@ -1227,7 +1227,7 @@ type User struct {
 	// addresses and CIDR ranges from which the user is allowed to connect
 	// to the server or from which the server can accept users.
 	//
-	// WARNING: Authentication Restrictions is only supported in version
+	// WARNING: Authentication Restrictions are only supported in version
 	// 3.6 and above.
 	AuthenticationRestrictions []AuthenticationRestriction `bson:"authenticationRestrictions,omitempty"`
 }

--- a/session.go
+++ b/session.go
@@ -1168,6 +1168,14 @@ func (s *Session) LogoutAll() {
 	s.m.Unlock()
 }
 
+// AuthenticationRestriction represents an authentication restriction
+// for a MongoDB User. Authentication Restrictions is a new feature
+// since version 3.6
+type AuthenticationRestriction struct {
+	ClientSource  []string `bson:"clientSource,omitempty"`
+	ServerAddress []string `bson:"serverAddress,omitempty"`
+}
+
 // User represents a MongoDB user.
 //
 // Relevant documentation:
@@ -1208,6 +1216,9 @@ type User struct {
 	// WARNING: This setting was only ever supported in MongoDB 2.4,
 	// and is now obsolete.
 	UserSource string `bson:"userSource,omitempty"`
+
+	// AuthenticationRestrictions ...
+	AuthenticationRestrictions []AuthenticationRestriction `bson:"authenticationRestrictions,omitempty"`
 }
 
 // Role available role for users
@@ -1369,6 +1380,9 @@ func (db *Database) runUserCmd(cmdName string, user *User) error {
 	}
 	if roles != nil || user.Roles != nil || cmdName == "createUser" {
 		cmd = append(cmd, bson.DocElem{Name: "roles", Value: roles})
+	}
+	if user.AuthenticationRestrictions != nil && len(user.AuthenticationRestrictions) > 0 {
+		cmd = append(cmd, bson.DocElem{Name: "authenticationRestrictions", Value: user.AuthenticationRestrictions})
 	}
 	err := db.Run(cmd, nil)
 	if !isNoCmd(err) && user.UserSource != "" && (user.UserSource != "$external" || db.Name != "$external") {

--- a/session.go
+++ b/session.go
@@ -1221,6 +1221,9 @@ type User struct {
 	// the server enforces on the created user. Specifies a list of IP
 	// addresses and CIDR ranges from which the user is allowed to connect
 	// to the server or from which the server can accept users.
+	//
+	// WARNING Authentication Restrictions is only supported in version 3.6
+	// and above.
 	AuthenticationRestrictions []AuthenticationRestriction `bson:"authenticationRestrictions,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds support for MongoDB user authenticationRestrictions, added in 3.6:

> The authentication restrictions the server enforces on the created user. Specifies a list of IP addresses and CIDR ranges from which the user is allowed to connect to the server or from which the server can accept users.

https://docs.mongodb.com/manual/reference/method/db.createUser/#authentication-restrictions

Example user with authenticationRestrictions, post-change:

```
> db.system.users.find({},{_id:0, credentials:0}).pretty()
{
	"user" : "tim",
	"db" : "admin",
	"roles" : [
		{
			"role" : "root",
			"db" : "admin"
		}
	],
	"authenticationRestrictions" : [
		{
			"clientSource" : [
				"127.0.0.1"
			],
			"serverAddress" : [
				"127.0.0.1"
			]
		}
	]
}
```

If it's valuable I can add checks to confirm a valid IP or CIDR was passed as 'clientSource' or 'serverAddress', please let me know.