### PR TITLE
Fix socket race condition

### DIFF
--- a/session.go
+++ b/session.go
@@ -5183,13 +5183,13 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 	s.m.RLock()
 	// If there is a slave socket reserved and its use is acceptable, take it as long
 	// as there isn't a master socket which would be preferred by the read preference mode.
-	if s.slaveSocket != nil && s.slaveSocket.dead == nil && s.slaveOk && slaveOk && (s.masterSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
+	if s.slaveSocket != nil && s.slaveSocket.Dead() == nil && s.slaveOk && slaveOk && (s.masterSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
 		socket := s.slaveSocket
 		socket.Acquire()
 		s.m.RUnlock()
 		return socket, nil
 	}
-	if s.masterSocket != nil && s.masterSocket.dead == nil {
+	if s.masterSocket != nil && s.masterSocket.Dead() == nil {
 		socket := s.masterSocket
 		socket.Acquire()
 		s.m.RUnlock()
@@ -5203,7 +5203,7 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 	defer s.m.Unlock()
 
 	if s.slaveSocket != nil && s.slaveOk && slaveOk && (s.masterSocket == nil || s.consistency != PrimaryPreferred && s.consistency != Monotonic) {
-		if s.slaveSocket.dead == nil {
+		if s.slaveSocket.Dead() == nil {
 			s.slaveSocket.Acquire()
 			return s.slaveSocket, nil
 		} else {
@@ -5211,7 +5211,7 @@ func (s *Session) acquireSocket(slaveOk bool) (*mongoSocket, error) {
 		}
 	}
 	if s.masterSocket != nil {
-		if s.masterSocket.dead == nil {
+		if s.masterSocket.Dead() == nil {
 			s.masterSocket.Acquire()
 			return s.masterSocket, nil
 		} else {

--- a/socket.go
+++ b/socket.go
@@ -213,8 +213,8 @@ func (socket *mongoSocket) Server() *mongoServer {
 	return server
 }
 
-// ServerInfo returns details for the server at the time the socket
-// was initially acquired.
+// ServerInfo returns details for the server at the time the socket was
+// initially acquired.
 func (socket *mongoSocket) ServerInfo() *mongoServerInfo {
 	if socket == nil {
 		return &mongoServerInfo{}
@@ -223,6 +223,16 @@ func (socket *mongoSocket) ServerInfo() *mongoServerInfo {
 	serverInfo := socket.serverInfo
 	socket.Unlock()
 	return serverInfo
+}
+
+// Dead returns the internal status of the socket
+//
+// It will return nil or an error if the socket is dead
+func (socket *mongoSocket) Dead() error {
+	socket.Lock()
+	defer socket.Unlock()
+
+	return socket.dead
 }
 
 // InitialAcquire obtains the first reference to the socket, either


### PR DESCRIPTION
Add lock protection when accessing socket dead attribute to prevent race condition. It should fix issue #135.