### PR TITLE
Allow the mongod binary to be defined in dbtest

### DIFF
--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -24,12 +24,13 @@ import (
 // Before the DBServer is used the SetPath method must be called to define
 // the location for the database files to be stored.
 type DBServer struct {
-	session *mgo.Session
-	output  bytes.Buffer
-	server  *exec.Cmd
-	dbpath  string
-	host    string
-	tomb    tomb.Tomb
+	session    *mgo.Session
+	output     bytes.Buffer
+	server     *exec.Cmd
+	dbpath     string
+	mongodpath string
+	host       string
+	tomb       tomb.Tomb
 }
 
 // SetPath defines the path to the directory where the database files will be
@@ -39,7 +40,16 @@ func (dbs *DBServer) SetPath(dbpath string) {
 	dbs.dbpath = dbpath
 }
 
+// SetMongodPath defines the path the the mongod server executable to be used
+// when starting a server.
+func (dbs *DBServer) SetMongodPath(mongodpath string) {
+	dbs.mongodpath = mongodpath
+}
+
 func (dbs *DBServer) start() {
+	if dbs.mongodpath == "" {
+		dbs.mongodpath = "mongod"
+	}
 	if dbs.server != nil {
 		panic("DBServer already started")
 	}
@@ -65,7 +75,7 @@ func (dbs *DBServer) start() {
 		"--nojournal",
 	}
 	dbs.tomb = tomb.Tomb{}
-	dbs.server = exec.Command("mongod", args...)
+	dbs.server = exec.Command(dbs.mongodpath, args...)
 	dbs.server.Stdout = &dbs.output
 	dbs.server.Stderr = &dbs.output
 	err = dbs.server.Start()

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -106,3 +106,16 @@ func (s *S) TestCheckSessionsDisabled(c *C) {
 	defer session.Close()
 	server.Wipe()
 }
+
+func (s *S) TestSetMongodPath(c *C) {
+	var server dbtest.DBServer
+
+	// check that the default is "mongod"
+	session := server.Session()
+	defer session.Close()
+	c.Assert(server.dbpath, Equals, "mongod")
+
+	// check .SetMongodPath()
+	server.SetMongodPath("/opt/mongod/bin/mongod")
+	c.Assert(server.dbpath, Equals, "/opt/mongod/bin/mongod")
+}


### PR DESCRIPTION
This PR adds support for defining the mongod binary to be used when starting the dbtest.DBServer.