### PR TITLE
Revert "Test against Mongo minor releases updates as of Aug 2018"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
         - FASTDL=https://fastdl.mongodb.org/linux
     matrix:
         - MONGODB=x86_64-ubuntu1404-3.0.15
-        - MONGODB=x86_64-ubuntu1404-3.2.20
-        - MONGODB=x86_64-ubuntu1404-3.4.16
-        - MONGODB=x86_64-ubuntu1404-3.6.6
+        - MONGODB=x86_64-ubuntu1404-3.2.17
+        - MONGODB=x86_64-ubuntu1404-3.4.10
+        - MONGODB=x86_64-ubuntu1404-3.6.0
 
 install:
 


### PR DESCRIPTION
Reverts globalsign/mgo#241. It was merged into master instead of development. 
A separate PR will track the merge into development.