### PR TITLE
Changestreams db and cluster level #251

### DIFF
--- a/changestreams.go
+++ b/changestreams.go
@@ -17,12 +17,12 @@ const (
 	UpdateLookup = "updateLookup"
 )
 
-type ChangeDomainType int
+type changeDomainType int
 
 const (
-	ChangeDomainCollection ChangeDomainType = iota
-	ChangeDomainDatabase
-	ChangeDomainCluster
+	changeDomainCollection changeDomainType = iota
+	changeDomainDatabase
+	changeDomainCluster
 )
 
 type ChangeStream struct {
@@ -36,7 +36,7 @@ type ChangeStream struct {
 	err            error
 	m              sync.Mutex
 	sessionCopied  bool
-	domainType     ChangeDomainType
+	domainType     changeDomainType
 	session        *Session
 	database       *Database
 }
@@ -72,7 +72,7 @@ func (c *Collection) Watch(pipeline interface{},
 		pipeline = []bson.M{}
 	}
 
-	csPipe := constructChangeStreamPipeline(pipeline, options, ChangeDomainCollection)
+	csPipe := constructChangeStreamPipeline(pipeline, options, changeDomainCollection)
 	pipe := c.Pipe(&csPipe)
 	if options.MaxAwaitTimeMS > 0 {
 		pipe.SetMaxTime(options.MaxAwaitTimeMS)
@@ -96,7 +96,7 @@ func (c *Collection) Watch(pipeline interface{},
 		resumeToken: nil,
 		options:     options,
 		pipeline:    pipeline,
-		domainType:  ChangeDomainCollection,
+		domainType:  changeDomainCollection,
 	}, nil
 }
 
@@ -109,7 +109,7 @@ func (sess *Session) Watch(pipeline interface{},
 		pipeline = []bson.M{}
 	}
 
-	csPipe := constructChangeStreamPipeline(pipeline, options, ChangeDomainCluster)
+	csPipe := constructChangeStreamPipeline(pipeline, options, changeDomainCluster)
 	pipe := sess.pipe(&csPipe)
 	if options.MaxAwaitTimeMS > 0 {
 		pipe.SetMaxTime(options.MaxAwaitTimeMS)
@@ -132,7 +132,7 @@ func (sess *Session) Watch(pipeline interface{},
 		resumeToken: nil,
 		options:     options,
 		pipeline:    pipeline,
-		domainType:  ChangeDomainCluster,
+		domainType:  changeDomainCluster,
 		session:     sess,
 	}, nil
 }
@@ -146,7 +146,7 @@ func (db *Database) Watch(pipeline interface{},
 		pipeline = []bson.M{}
 	}
 
-	csPipe := constructChangeStreamPipeline(pipeline, options, ChangeDomainDatabase)
+	csPipe := constructChangeStreamPipeline(pipeline, options, changeDomainDatabase)
 	pipe := db.pipe(&csPipe)
 	if options.MaxAwaitTimeMS > 0 {
 		pipe.SetMaxTime(options.MaxAwaitTimeMS)
@@ -169,7 +169,7 @@ func (db *Database) Watch(pipeline interface{},
 		resumeToken: nil,
 		options:     options,
 		pipeline:    pipeline,
-		domainType:  ChangeDomainDatabase,
+		domainType:  changeDomainDatabase,
 		session:     db.Session,
 		database:    db,
 	}, nil
@@ -300,7 +300,7 @@ func (changeStream *ChangeStream) Timeout() bool {
 }
 
 func constructChangeStreamPipeline(pipeline interface{},
-	options ChangeStreamOptions, domain ChangeDomainType) interface{} {
+	options ChangeStreamOptions, domain changeDomainType) interface{} {
 	pipelinev := reflect.ValueOf(pipeline)
 
 	// ensure that the pipeline passed in is a slice.
@@ -318,7 +318,7 @@ func constructChangeStreamPipeline(pipeline interface{},
 	if options.ResumeAfter != nil {
 		changeStreamStageOptions["resumeAfter"] = options.ResumeAfter
 	}
-	if domain == ChangeDomainCluster {
+	if domain == changeDomainCluster {
 		changeStreamStageOptions["allChangesForCluster"] = true
 	}
 
@@ -368,11 +368,11 @@ func (changeStream *ChangeStream) resume() error {
 
 	// generate the new iterator with the new connection.
 	var newPipe *Pipe
-	if changeStream.domainType == ChangeDomainCollection {
+	if changeStream.domainType == changeDomainCollection {
 		newPipe = changeStream.collection.Pipe(changeStreamPipeline)
-	} else if changeStream.domainType == ChangeDomainCluster {
+	} else if changeStream.domainType == changeDomainCluster {
 		newPipe = changeStream.session.pipe(changeStreamPipeline)
-	} else if changeStream.domainType == ChangeDomainDatabase {
+	} else if changeStream.domainType == changeDomainDatabase {
 		newPipe = changeStream.database.pipe(changeStreamPipeline)
 	}
 

--- a/changestreams_test.go
+++ b/changestreams_test.go
@@ -25,6 +25,15 @@ type changeEvent struct {
 	UpdateDescription *updateDesc `bson:"updateDescription,omitempty"`
 }
 
+type watchable interface {
+	Watch(pipeline interface{}, options mgo.ChangeStreamOptions) (*mgo.ChangeStream, error)
+}
+
+// type nextable interface {
+// 	Next(result interface{}) bool
+// 	Close() error
+// }
+
 func (s *S) TestStreamsWatch(c *C) {
 	if !s.versionAtLeast(3, 6) {
 		c.Skip("ChangeStreams only work on 3.6+")
@@ -37,11 +46,21 @@ func (s *S) TestStreamsWatch(c *C) {
 	coll.Insert(M{"a": 0})
 
 	pipeline := []bson.M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{})
-	c.Assert(err, IsNil)
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+	var testF = func(w watchable) {
+		changeStream, err := w.Watch(pipeline, mgo.ChangeStreamOptions{})
+		c.Assert(err, IsNil)
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+	}
+	//collection level
+	testF(coll)
+	if s.versionAtLeast(4, 0) {
+		//db level
+		testF(session.DB("mydb"))
+		//cluster level
+		testF(session)
+	}
 }
 
 func (s *S) TestStreamsInsert(c *C) {
@@ -53,45 +72,71 @@ func (s *S) TestStreamsInsert(c *C) {
 	defer session.Close()
 
 	coll := session.DB("mydb").C("mycoll")
-
 	//add a mock document in order for the DB to be created
 	err = coll.Insert(M{"a": 0})
 	c.Assert(err, IsNil)
 
-	//create the stream
-	pipeline := []M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
-	c.Assert(err, IsNil)
+	//for db level changeStream we need to ensure the event goes only to the right db
+	//so we create a dummy db.
+	if s.versionAtLeast(4, 0) {
+		err = session.DB("wrong_dummy_mydb").C("mycoll").Insert(M{"a": 0})
+		c.Assert(err, IsNil)
+	}
 
-	//insert a new document
-	id := bson.NewObjectId()
-	err = coll.Insert(M{"_id": id, "a": 1})
-	c.Assert(err, IsNil)
+	pipeline := []M{}
+
 	//get the _id for later check
 	type A struct {
 		ID bson.ObjectId `bson:"_id"`
 		A  int           `bson:"a"`
 	}
 
-	//get the event
-	ev := changeEvent{}
-	hasEvent := changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, true)
+	var hasEvent bool
+	var id bson.ObjectId
 
-	//check event is correct
-	oid := ev.DocumentKey["_id"].(bson.ObjectId)
-	c.Assert(oid, Equals, id)
-	c.Assert(ev.OperationType, Equals, "insert")
-	c.Assert(ev.FullDocument, NotNil)
-	a := A{}
-	err = ev.FullDocument.Unmarshal(&a)
-	c.Assert(err, IsNil)
-	c.Assert(a.A, Equals, 1)
-	c.Assert(ev.Ns.DB, Equals, "mydb")
-	c.Assert(ev.Ns.Coll, Equals, "mycoll")
+	// checkEv will check the event is correct
+	var checkEv = func(ev changeEvent) {
+		oid := ev.DocumentKey["_id"].(bson.ObjectId)
+		c.Assert(oid, Equals, id)
+		c.Assert(ev.OperationType, Equals, "insert")
+		c.Assert(ev.FullDocument, NotNil)
+		a := A{}
+		e := ev.FullDocument.Unmarshal(&a)
+		c.Assert(e, IsNil)
+		c.Assert(a.A, Equals, 1)
+		c.Assert(ev.Ns.DB, Equals, "mydb")
+		c.Assert(ev.Ns.Coll, Equals, "mycoll")
+	}
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+	var testF = func(w watchable, shouldHaveEv bool) {
+		changeStream, e := w.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
+		c.Assert(e, IsNil)
+		//insert a new document
+		id = bson.NewObjectId()
+		e = coll.Insert(M{"_id": id, "a": 1})
+		c.Assert(e, IsNil)
+		//collection level
+		//get the event from the stream
+		changeEv := changeEvent{}
+		hasEvent = changeStream.Next(&changeEv)
+		c.Assert(hasEvent, Equals, shouldHaveEv)
+		if shouldHaveEv {
+			checkEv(changeEv)
+		}
+		e = changeStream.Close()
+		c.Assert(e, IsNil)
+	}
+
+	//collection level stream
+	testF(coll, true)
+	if s.versionAtLeast(4, 0) {
+		//db level stream
+		testF(session.DB("mydb"), true)
+		//ensure that the event is not passed to the wrong dummy db changestream
+		testF(session.DB("wrong_dummy_mydb"), false)
+		//cluster level stream
+		testF(session, true)
+	}
 }
 
 func (s *S) TestStreamsNextNoEventTimeout(c *C) {
@@ -111,28 +156,40 @@ func (s *S) TestStreamsNextNoEventTimeout(c *C) {
 
 	//create the stream
 	pipeline := []M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
-	c.Assert(err, IsNil)
 
-	//check we timeout correctly on no events
-	//we should get a false result and no error
-	ev := changeEvent{}
-	hasEvent := changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, false)
-	c.Assert(changeStream.Err(), IsNil)
-	c.Assert(changeStream.Timeout(), Equals, true)
+	var testF = func(w watchable) {
+		changeStream, err := w.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
+		c.Assert(err, IsNil)
 
-	//test the same with default timeout (MaxTimeMS=1000)
-	//create the stream
-	changeStream, err = coll.Watch(pipeline, mgo.ChangeStreamOptions{})
-	c.Assert(err, IsNil)
-	hasEvent = changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, false)
-	c.Assert(changeStream.Err(), IsNil)
-	c.Assert(changeStream.Timeout(), Equals, true)
+		//check we timeout correctly on no events
+		//we should get a false result and no error
+		ev := changeEvent{}
+		hasEvent := changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, false)
+		c.Assert(changeStream.Err(), IsNil)
+		c.Assert(changeStream.Timeout(), Equals, true)
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+		//test the same with default timeout (MaxTimeMS=1000)
+		//create the stream
+		changeStream, err = w.Watch(pipeline, mgo.ChangeStreamOptions{})
+		c.Assert(err, IsNil)
+		hasEvent = changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, false)
+		c.Assert(changeStream.Err(), IsNil)
+		c.Assert(changeStream.Timeout(), Equals, true)
+
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+	}
+
+	//collection level stream
+	testF(coll)
+	if s.versionAtLeast(4, 0) {
+		//db level stream
+		testF(session.DB("mydb"))
+		//cluster level stream
+		testF(session)
+	}
 }
 
 func (s *S) TestStreamsNextTimeout(c *C) {
@@ -150,41 +207,53 @@ func (s *S) TestStreamsNextTimeout(c *C) {
 	err = coll.Insert(M{"_id": id, "a": 0})
 	c.Assert(err, IsNil)
 
-	//create the stream
 	pipeline := []M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
-	c.Assert(err, IsNil)
 
-	//insert a new document to trigger an event
-	id = bson.NewObjectId()
-	err = coll.Insert(M{"_id": id, "a": 1})
-	c.Assert(err, IsNil)
+	var testF = func(w watchable) {
+		//create the stream
+		changeStream, err := w.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
+		c.Assert(err, IsNil)
 
-	//ensure we get the event
-	ev := changeEvent{}
-	hasEvent := changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, true)
+		//insert a new document to trigger an event
+		id = bson.NewObjectId()
+		err = coll.Insert(M{"_id": id, "a": 1})
+		c.Assert(err, IsNil)
 
-	//check we timeout correctly on no subsequent events
-	//we should get a false result and no error
-	ev = changeEvent{}
-	hasEvent = changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, false)
-	c.Assert(changeStream.Err(), IsNil)
-	c.Assert(changeStream.Timeout(), Equals, true)
+		//ensure we get the event
+		ev := changeEvent{}
+		hasEvent := changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, true)
 
-	//insert a new document to trigger an event
-	id = bson.NewObjectId()
-	err = coll.Insert(M{"_id": id, "a": 1})
-	c.Assert(err, IsNil)
+		//check we timeout correctly on no subsequent events
+		//we should get a false result and no error
+		ev = changeEvent{}
+		hasEvent = changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, false)
+		c.Assert(changeStream.Err(), IsNil)
+		c.Assert(changeStream.Timeout(), Equals, true)
 
-	//ensure we get the event
-	ev = changeEvent{}
-	hasEvent = changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, true)
+		//insert a new document to trigger an event
+		id = bson.NewObjectId()
+		err = coll.Insert(M{"_id": id, "a": 1})
+		c.Assert(err, IsNil)
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+		//ensure we get the event
+		ev = changeEvent{}
+		hasEvent = changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, true)
+
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+	}
+	//collection level stream
+	testF(coll)
+	if s.versionAtLeast(4, 0) {
+		//db level stream
+		testF(session.DB("mydb"))
+		//cluster level stream
+		testF(session)
+	}
+
 }
 
 func (s *S) TestStreamsDelete(c *C) {
@@ -198,34 +267,46 @@ func (s *S) TestStreamsDelete(c *C) {
 	coll := session.DB("mydb").C("mycoll")
 
 	//add a mock document in order for the DB to be created
-	id := bson.NewObjectId()
-	err = coll.Insert(M{"_id": id, "a": 0})
-	c.Assert(err, IsNil)
 
-	//create the changeStream
 	pipeline := []M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
-	c.Assert(err, IsNil)
 
-	//delete the document
-	err = coll.Remove(M{"_id": id})
-	c.Assert(err, IsNil)
+	var testF = func(w watchable) {
+		id := bson.NewObjectId()
+		err = coll.Insert(M{"_id": id, "a": 0})
+		c.Assert(err, IsNil)
 
-	//get the event
-	ev := changeEvent{}
-	hasEvent := changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, true)
+		//create the changeStream
+		changeStream, err := w.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
+		c.Assert(err, IsNil)
 
-	//check event is correct
-	oid := ev.DocumentKey["_id"].(bson.ObjectId)
-	c.Assert(oid, Equals, id)
-	c.Assert(ev.OperationType, Equals, "delete")
-	c.Assert(ev.FullDocument, IsNil)
-	c.Assert(ev.Ns.DB, Equals, "mydb")
-	c.Assert(ev.Ns.Coll, Equals, "mycoll")
+		//delete the document
+		err = coll.Remove(M{"_id": id})
+		c.Assert(err, IsNil)
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+		//get the event
+		ev := changeEvent{}
+		hasEvent := changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, true)
+
+		//check event is correct
+		oid := ev.DocumentKey["_id"].(bson.ObjectId)
+		c.Assert(oid, Equals, id)
+		c.Assert(ev.OperationType, Equals, "delete")
+		c.Assert(ev.FullDocument, IsNil)
+		c.Assert(ev.Ns.DB, Equals, "mydb")
+		c.Assert(ev.Ns.Coll, Equals, "mycoll")
+
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+	}
+	//collection level stream
+	testF(coll)
+	if s.versionAtLeast(4, 0) {
+		//db level stream
+		testF(session.DB("mydb"))
+		//cluster level stream
+		testF(session)
+	}
 }
 
 func (s *S) TestStreamsUpdate(c *C) {
@@ -238,39 +319,50 @@ func (s *S) TestStreamsUpdate(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 
-	//add a mock document in order for the DB to be created
-	id := bson.NewObjectId()
-	err = coll.Insert(M{"_id": id, "a": 0, "toremove": 2})
-	c.Assert(err, IsNil)
-
 	//create the stream
 	pipeline := []M{}
-	changeStream, err := coll.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
-	c.Assert(err, IsNil)
 
-	//update document
-	err = coll.UpdateId(id, M{"$set": M{"a": 1}, "$unset": M{"toremove": ""}})
-	c.Assert(err, IsNil)
+	var testF = func(w watchable) {
+		//add a mock document in order for the DB to be created
+		id := bson.NewObjectId()
+		err = coll.Insert(M{"_id": id, "a": 0, "toremove": 2})
+		c.Assert(err, IsNil)
 
-	//get the event
-	ev := changeEvent{}
-	hasEvent := changeStream.Next(&ev)
-	c.Assert(hasEvent, Equals, true)
+		changeStream, err := w.Watch(pipeline, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
+		c.Assert(err, IsNil)
 
-	//check event is correct
-	oid := ev.DocumentKey["_id"].(bson.ObjectId)
-	c.Assert(oid, Equals, id)
-	c.Assert(ev.OperationType, Equals, "update")
-	c.Assert(ev.FullDocument, IsNil)
-	c.Assert(len(ev.UpdateDescription.UpdatedFields), Equals, 1)
-	c.Assert(len(ev.UpdateDescription.RemovedFields), Equals, 1)
-	c.Assert(ev.UpdateDescription.UpdatedFields["a"], Equals, 1)
-	c.Assert(ev.UpdateDescription.RemovedFields[0], Equals, "toremove")
-	c.Assert(ev.Ns.DB, Equals, "mydb")
-	c.Assert(ev.Ns.Coll, Equals, "mycoll")
+		//update document
+		err = coll.UpdateId(id, M{"$set": M{"a": 1}, "$unset": M{"toremove": ""}})
+		c.Assert(err, IsNil)
 
-	err = changeStream.Close()
-	c.Assert(err, IsNil)
+		//get the event
+		ev := changeEvent{}
+		hasEvent := changeStream.Next(&ev)
+		c.Assert(hasEvent, Equals, true)
+
+		//check event is correct
+		oid := ev.DocumentKey["_id"].(bson.ObjectId)
+		c.Assert(oid, Equals, id)
+		c.Assert(ev.OperationType, Equals, "update")
+		c.Assert(ev.FullDocument, IsNil)
+		c.Assert(len(ev.UpdateDescription.UpdatedFields), Equals, 1)
+		c.Assert(len(ev.UpdateDescription.RemovedFields), Equals, 1)
+		c.Assert(ev.UpdateDescription.UpdatedFields["a"], Equals, 1)
+		c.Assert(ev.UpdateDescription.RemovedFields[0], Equals, "toremove")
+		c.Assert(ev.Ns.DB, Equals, "mydb")
+		c.Assert(ev.Ns.Coll, Equals, "mycoll")
+
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+	}
+	//collection level stream
+	testF(coll)
+	if s.versionAtLeast(4, 0) {
+		//db level stream
+		testF(session.DB("mydb"))
+		//cluster level stream
+		testF(session)
+	}
 }
 
 func (s *S) TestStreamsUpdateFullDocument(c *C) {

--- a/changestreams_test.go
+++ b/changestreams_test.go
@@ -121,7 +121,6 @@ func (s *S) TestStreamsInsert(c *C) {
 		e = changeStream.Close()
 		c.Assert(e, IsNil)
 	}
-
 	//collection level stream
 	testF(coll, true)
 	if s.versionAtLeast(4, 0) {


### PR DESCRIPTION
Enhancing change streams in order to support DB level and cluster level changes notifications introduced in mongoDB 4.0 as per issue #251.
I strongly ask review of the way i addressed the question as i'm not really sure it is not a workaround.
If we go this way, i think it's better to make unexported all session and database methods that were added (`Pipe()`, `NewIter()`), except for the `Watch()` method in order to not pollute with meaningless methods.
**Tests are still missing** and will be added once we agree on the way i implemented the functionality and Mongo 4.0 is added to the test suite.