### PR TITLE
Backport issue template & support notes

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,29 @@
+We use the issue tracker to track bugs with mgo - if you have a usage question,
+it's best to try Stack Overflow :)
+
+Replace this text with your description, and please answer the questions below
+before submitting your issue to help us out. Thanks!
+
+-------------------------------------------------------------------------------
+
+### What version of MongoDB are you using (`mongod --version`)?
+```
+<mongodb version here>
+```
+
+### What version of Go are you using (`go version`)?
+```
+<go version here>
+```
+
+### What operating system and processor architecture are you using (`go env`)?
+```
+<go env here>
+```
+
+### What did you do?
+
+If possible, provide a recipe for reproducing the error.
+A runnable program is great and really helps!
+
+### Can you reproduce the issue on the latest `development` branch?

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Detailed documentation of the API is available at
 
 A [sub-package](https://godoc.org/github.com/globalsign/mgo/bson) that implements the [BSON](http://bsonspec.org) specification is also included, and may be used independently of the driver.
 
+## Supported Versions
+
+`mgo` is known to work well on (and has integration tests against) MongoDB v3.0, 3.2, 3.4 and 3.6. 
+
+MongoDB 4.0 is currently experimental - we would happily accept PRs to help improve support!
+
 ## Changes
 * Fixes attempting to authenticate before every query ([details](https://github.com/go-mgo/mgo/issues/254))
 * Removes bulk update / delete batch size limitations ([details](https://github.com/go-mgo/mgo/issues/288))


### PR DESCRIPTION
GitHub history is a little messed up.

Backports #263 to `development`.