### PR TITLE
mgo/dbtest: Set wiredTiger cache size so that it does not default to 50% RAM

### DIFF
--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -78,8 +78,11 @@ func (dbs *DBServer) start() {
 		"--port", strconv.Itoa(addr.Port),
 		"--storageEngine=" + dbs.engine,
 	}
-	if dbs.engine == "mmapv1" {
-		// default to mmapv1 and add mmapv1-only args (nssize, noprealloc, smallfiles and nojournal)
+
+	switch dbs.engine {
+	case "wiredTiger":
+		args = append(args, "--wiredTigerCacheSizeGB=0.1")
+	case "mmapv1":
 		args = append(args,
 			"--nssize", "1",
 			"--noprealloc",


### PR DESCRIPTION
By default wiredTiger will set it's cache size to 50% of the available RAM, even when inside docker, etc.

This PR changes wiredTiger to use only 100MB of RAM for cache (0.1GB) in tests.