### PR TITLE
Lazy initialization of coarse time goroutine

### DIFF
--- a/server.go
+++ b/server.go
@@ -44,8 +44,15 @@ import (
 // coarseTimeProvider).
 var coarseTime *coarseTimeProvider
 
-func init() {
-	coarseTime = newcoarseTimeProvider(25 * time.Millisecond)
+// coarseTimeOnce is used to ensure we create a single coarseTime instance.
+var coarseTimeOnce sync.Once
+
+// initCoarseTime is used to ensure the global coarseTime is initialized.
+func initCoarseTime() *coarseTimeProvider {
+	coarseTimeOnce.Do(func() {
+		coarseTime = newcoarseTimeProvider(25 * time.Millisecond)
+	})
+	return coarseTime
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +98,7 @@ type mongoServerInfo struct {
 var defaultServerInfo mongoServerInfo
 
 func newServer(addr string, tcpaddr *net.TCPAddr, syncChan chan bool, dial dialer, info *DialInfo) *mongoServer {
+	initCoarseTime()
 	server := &mongoServer{
 		Addr:         addr,
 		ResolvedAddr: tcpaddr.String(),


### PR DESCRIPTION
Initializing the coarseTime goroutine in the init() call had a pretty serious side effect. It was impossible to override the value of `time.Local` without causing a race condition, because its value is used
on `NewTicker` calls.

This PR changes the previous behavior by only initializing the coarseTime goroutine when the first server is created. Allowing programs to possibly override time.Local before mgo is initialized.