### PR TITLE
Fix debug call formatting and run everything through go fmt.

### DIFF
--- a/bson/decimal_test.go
+++ b/bson/decimal_test.go
@@ -1,4 +1,4 @@
-﻿// BSON library for Go
+// BSON library for Go
 //
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
 //

--- a/gridfs.go
+++ b/gridfs.go
@@ -678,7 +678,7 @@ func (file *GridFile) insertChunk(data []byte) {
 // an error, if any.
 func (file *GridFile) Seek(offset int64, whence int) (pos int64, err error) {
 	file.m.Lock()
-	debugf("GridFile %p: seeking for %s (whence=%d)", file, offset, whence)
+	debugf("GridFile %p: seeking for %d (whence=%d)", file, offset, whence)
 	defer file.m.Unlock()
 	switch whence {
 	case os.SEEK_SET:

--- a/server_test.go
+++ b/server_test.go
@@ -42,10 +42,10 @@ func (s *S) TestServerRecoversFromAbend(c *C) {
 	server := cluster.Server("127.0.0.1:40001")
 
 	info := &mgo.DialInfo{
-		Timeout: time.Second,
+		Timeout:   time.Second,
 		PoolLimit: 100,
 	}
-	
+
 	sock, abended, err := server.AcquireSocket(info)
 	c.Assert(err, IsNil)
 	c.Assert(sock, NotNil)

--- a/session.go
+++ b/session.go
@@ -2912,7 +2912,6 @@ func (p *Pipe) SetMaxTime(d time.Duration) *Pipe {
 	return p
 }
 
-
 // Collation allows to specify language-specific rules for string comparison,
 // such as rules for lettercase and accent marks.
 // When specifying collation, the locale field is mandatory; all other collation
@@ -3885,7 +3884,7 @@ func (db *Database) run(socket *mongoSocket, cmd, result interface{}) (err error
 	if result != nil {
 		err = bson.Unmarshal(data, result)
 		if err != nil {
-			debugf("Run command unmarshaling failed: %#v", op, err)
+			debugf("Run command unmarshaling failed: %#v, error: %#v", op, err)
 			return err
 		}
 		if globalDebug && globalLogger != nil {


### PR DESCRIPTION
Some arguments for debugf calls were missing arguments or using incorrect formatting strings, this caused the following error when trying to run tests:

```
$ go test .
./gridfs.go:681: debugf format %s has arg offset of wrong type int64
./session.go:3888: debugf call needs 1 arg but has 2 args
FAIL	github.com/globalsign/mgo [build failed]
```