### PR TITLE
Partial 4.0 Transaction support

### DIFF
--- a/40_TRANSACTION_CHANGES.md
+++ b/40_TRANSACTION_CHANGES.md
@@ -1,0 +1,1 @@
+package mgo

--- a/40_TRANSACTION_CHANGES.md
+++ b/40_TRANSACTION_CHANGES.md
@@ -1,1 +1,81 @@
-package mgo
+
+Home Depot provides these changes for community use with the usual
+caveats - no warranty, etc.
+
+This code contains the following changes - which will be pushed back
+to the parent repo (globalsign/mgo)
+
+* 4.0 Transaction Support
+
+## How To Use Transaction Support
+
+If you don't want to use 4.0 transaction support, do nothing.
+It will not be enabled and nothing will happen.
+
+If you need to use transaction support, do the following:
+
+- Create a Transaction object
+
+```
+// This populates the Session object with a Session ID.
+// This is required for transactions, but not in other cases.
+err := m.Session.Start()
+if err != nil {
+    panic(err.Error())
+}
+// Create a new transaction object
+tr := mgo.NewTransaction(m.Session)
+m.Transaction = &tr
+```
+
+- Use the provided update functions
+
+```
+c.UpsertTransaction(tr, ...)
+c.InsertTransaction(tr, ...)
+c.RemoveTransaction(tr, ...)
+c.UpdateTransaction(tr, ...)
+```
+
+- Commit or abort the transactions when you are finished.
+
+```
+tr.Commit()
+tr.Abort()
+```
+
+## Replication
+
+In order to adjust the tests to use replication (because the default
+server install doesn't use replication), we made adjustments to allow
+the dbtest server to set up as a single-server replica set.  To enable,
+instead of
+
+```
+var Server DBServer
+Server.Session()
+```
+
+use
+
+```
+var Server DBServer
+Server.SessionRepl(true)
+```
+
+You can also use
+
+```
+Server.SessionRepl(false)
+```
+
+to duplicate the behavior of
+```
+Server.Session()
+```
+
+
+Caveats:
+
+- You can create more than one transaction object, but only use one at a time.
+- More docs to come.

--- a/bulk.go
+++ b/bulk.go
@@ -367,7 +367,7 @@ func (b *Bulk) Run() (*BulkResult, error) {
 }
 
 func (b *Bulk) runInsert(action *bulkAction, result *BulkResult, berr *BulkError) bool {
-	op := &insertOp{b.c.FullName, action.docs, 0}
+	op := &insertOp{b.c.FullName, action.docs, 0, nil}
 	if !b.ordered {
 		op.flags = 1 // ContinueOnError
 	}

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -59,7 +59,7 @@ func (dbs *DBServer) SetWiredTigerCacheSize(sizeGB float64) {
 	dbs.wtCacheSizeGB = sizeGB
 }
 
-func (dbs *DBServer) start() {
+func (dbs *DBServer) start(repl bool) {
 	if dbs.engine == "" {
 		dbs.engine = "mmapv1"
 	}
@@ -91,6 +91,9 @@ func (dbs *DBServer) start() {
 			dbs.wtCacheSizeGB = 0.1
 		}
 		args = append(args, fmt.Sprintf("--wiredTigerCacheSizeGB=%.2f", dbs.wtCacheSizeGB))
+		if repl {
+			args = append(args, "--replSet=rs0")
+		}
 	case "mmapv1":
 		args = append(args,
 			"--nssize", "1",
@@ -110,10 +113,25 @@ func (dbs *DBServer) start() {
 		fmt.Fprintf(os.Stderr, "mongod failed to start: %v\n", err)
 		panic(err)
 	}
+	// Give the db time to settle.  This seems to matter on docker instances.
+	time.Sleep(1 * time.Second)
+	if repl {
+		dbs.initiateRepl(addr.Port)
+	}
 	if !dbs.disableMonitor {
 		dbs.tomb.Go(dbs.monitor)
 	}
 	dbs.Wipe()
+}
+
+func (dbs *DBServer) initiateRepl(port int) {
+	args := []string{
+		"localhost:" + strconv.Itoa(port),
+		"--eval", "rs.initiate()",
+	}
+	shell := exec.Command("mongo", args...)
+	// This should tank on an error.
+	shell.Start()
 }
 
 func (dbs *DBServer) monitor() error {
@@ -172,8 +190,12 @@ func (dbs *DBServer) Stop() {
 //
 // The first Session obtained from a DBServer will start it.
 func (dbs *DBServer) Session() *mgo.Session {
+	return dbs.SessionRepl(false)
+}
+
+func (dbs *DBServer) SessionRepl(repl bool) *mgo.Session {
 	if dbs.server == nil {
-		dbs.start()
+		dbs.start(repl)
 	}
 	if dbs.session == nil {
 		mgo.ResetStats()

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -49,7 +49,7 @@ func (s *S) TestWipeData(c *C) {
 	session.Close()
 	c.Assert(err, IsNil)
 	for _, name := range names {
-		if name != "local" && name != "admin" {
+		if name != "local" && name != "admin" && name != "config" {
 			c.Fatalf("Wipe should have removed this database: %s", name)
 		}
 	}
@@ -107,14 +107,12 @@ func (s *S) TestCheckSessionsDisabled(c *C) {
 	server.Wipe()
 }
 
-func (s *S) TestSetEngine(c *C) {
+func (s *S) TestMmapSetEngine(c *C) {
 	status := struct {
 		StorageEngine struct {
 			Name string `bson:"name"`
 		} `bson:"storageEngine"`
 	}{}
-	wtStatus := status
-
 	// mmapv1 (default)
 	var mmapServer dbtest.DBServer
 	mmapServer.SetPath(c.MkDir())
@@ -126,7 +124,14 @@ func (s *S) TestSetEngine(c *C) {
 	err := mSession.Run("serverStatus", &status)
 	c.Assert(err, IsNil)
 	c.Assert(status.StorageEngine.Name, Equals, "mmapv1")
+}
 
+func (s *S) TestWiredTigerSetEngine(c *C) {
+	status := struct {
+		StorageEngine struct {
+			Name string `bson:"name"`
+		} `bson:"storageEngine"`
+	}{}
 	// wiredTiger
 	var wtServer dbtest.DBServer
 	wtServer.SetPath(c.MkDir())
@@ -136,7 +141,7 @@ func (s *S) TestSetEngine(c *C) {
 	wSession := wtServer.Session()
 	defer wSession.Close()
 
-	err = wSession.Run("serverStatus", &wtStatus)
+	err := wSession.Run("serverStatus", &status)
 	c.Assert(err, IsNil)
-	c.Assert(wtStatus.StorageEngine.Name, Equals, "wiredTiger")
+	c.Assert(status.StorageEngine.Name, Equals, "wiredTiger")
 }

--- a/harness/daemons/.env
+++ b/harness/daemons/.env
@@ -1,9 +1,13 @@
 
 set -e
 
-MONGOVERSION=$(mongod --version | sed -n 's/.*v\([0-9]\+\.[0-9]\+\)\..*/\1/p')
-MONGOMAJOR=$(echo $MONGOVERSION | sed 's/\([0-9]\+\)\..*/\1/')
-MONGOMINOR=$(echo $MONGOVERSION | sed 's/[0-9]\+\.\([0-9]\+\)/\1/')
+if [ -z "$SED" ]; then
+    SED="sed"
+fi
+
+MONGOVERSION=$(mongod --version | $SED -n 's/.*v\([0-9]\+\.[0-9]\+\)\..*/\1/p')
+MONGOMAJOR=$(echo $MONGOVERSION | $SED 's/\([0-9]\+\)\..*/\1/')
+MONGOMINOR=$(echo $MONGOVERSION | $SED 's/[0-9]\+\.\([0-9]\+\)/\1/')
 
 versionAtLeast() {
 	TESTMAJOR="$1"
@@ -51,20 +55,20 @@ MONGOS3OPTS="--configdb 127.0.0.1:40103"
 if versionAtLeast 3 2; then
 
     # 3.2 doesn't like --nojournal on config servers.
-	COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+	COMMONCOPTS="$(echo "$COMMONCOPTS" | $SED '/--nojournal/d')"
 
     if versionAtLeast 3 4; then
       # http interface is disabled by default, this option does not exist anymore
       COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nohttpinterface/d')"
-      COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nohttpinterface/d')"
-      COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nohttpinterface/d')"
+      COMMONDOPTS="$(echo "$COMMONDOPTS" | $SED '/--nohttpinterface/d')"
+      COMMONCOPTS="$(echo "$COMMONCOPTS" | $SED '/--nohttpinterface/d')"
 
 
 		if versionAtLeast 3 6; then
 			#In version 3.6 --nojournal is deprecated for replica set members using WiredTiger
 			COMMONDOPTSNOIP="$(echo "$COMMONDOPTSNOIP" | sed '/--nojournal/d')"
-      COMMONDOPTS="$(echo "$COMMONDOPTS" | sed '/--nojournal/d')"
-      COMMONCOPTS="$(echo "$COMMONCOPTS" | sed '/--nojournal/d')"
+      COMMONDOPTS="$(echo "$COMMONDOPTS" | $SED '/--nojournal/d')"
+      COMMONCOPTS="$(echo "$COMMONCOPTS" | $SED '/--nojournal/d')"
 		fi
 
       # config server need to be started as replica set

--- a/session.go
+++ b/session.go
@@ -2496,6 +2496,70 @@ func (s *Session) Ping() error {
 	return s.Run("ping", nil)
 }
 
+// Start creates a session and saves the ID for future use in transactions.
+func (s *Session) Start() error {
+	var r sessionResult
+	err := s.Run("startSession", &r)
+	if err != nil {
+		return err
+	}
+	imap := r.ID.(bson.M)
+	// RJM
+	logf("id: %+v", r.ID)
+	s.SessionID = imap["id"].(bson.Binary)
+	return nil
+}
+
+// End kills the session and resets the ID in the struct.
+// Probably also aborts any existing transactions.
+func (s *Session) End() error {
+	var r sessionResult
+	cmd := bson.D{
+		{Name: "endSessions", Value: bson.M{"id": s.SessionID}},
+	}
+	s.SessionID = bson.Binary{}
+	return s.Run(cmd, &r)
+}
+
+// CommitTransaction commits the currently running transaction.
+// There are two bits of necessary info here:  the Session ID
+// and the transaction number.  Both are required, even though
+// they are by necessity stored in different locations.
+func (s *Session) CommitTransaction(n int64) error {
+	if len(s.SessionID.Data) == 0 {
+		return nil
+	}
+	cmd := bson.D{
+		{Name: "commitTransaction", Value: 1},
+		{Name: "txnNumber", Value: n},
+		{Name: "autocommit", Value: false},
+		{Name: "lsid", Value: bson.M{"id": s.SessionID}},
+	}
+	err := s.Run(cmd, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// AbortTransaction aborts the specified transaction.
+func (s *Session) AbortTransaction(n int64) error {
+	if len(s.SessionID.Data) == 0 {
+		return nil
+	}
+	cmd := bson.D{
+		{Name: "abortTransaction", Value: 1},
+		{Name: "txnNumber", Value: n},
+		{Name: "autocommit", Value: false},
+		{Name: "lsid", Value: bson.M{"id": s.SessionID}},
+	}
+	err := s.Run(cmd, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Fsync flushes in-memory writes to disk on the server the session
 // is established with. If async is true, the call returns immediately,
 // otherwise it returns after the flush has been made.
@@ -3074,8 +3138,15 @@ func IsDup(err error) bool {
 // happens while inserting the provided documents, the returned error will
 // be of type *LastError.
 func (c *Collection) Insert(docs ...interface{}) error {
-	_, err := c.writeOp(&insertOp{c.FullName, docs, 0}, true)
+	_, err := c.writeOp(&insertOp{c.FullName, docs, 0, nil}, true)
 	return err
+}
+
+// InsertTransaction inserts using a transaction.  See Insert().
+func (c *Collection) InsertTransaction(t *Transaction, docs ...interface{}) error {
+	_, err := c.writeOp(&insertOp{c.FullName, docs, 0, t}, true)
+	return err
+
 }
 
 // Update finds a single document matching the provided selector document
@@ -3089,7 +3160,14 @@ func (c *Collection) Insert(docs ...interface{}) error {
 //     http://www.mongodb.org/display/DOCS/Updating
 //     http://www.mongodb.org/display/DOCS/Atomic+Operations
 //
+
 func (c *Collection) Update(selector interface{}, update interface{}) error {
+	err := c.UpdateTransaction(nil, selector, update)
+	return err
+}
+
+// Update updates using a transaction.  See Update().
+func (c *Collection) UpdateTransaction(t *Transaction, selector interface{}, update interface{}) error {
 	if selector == nil {
 		selector = bson.D{}
 	}
@@ -3097,6 +3175,7 @@ func (c *Collection) Update(selector interface{}, update interface{}) error {
 		Collection: c.FullName,
 		Selector:   selector,
 		Update:     update,
+		Txn:        t,
 	}
 	lerr, err := c.writeOp(&op, true)
 	if err == nil && lerr != nil && !lerr.UpdatedExisting {
@@ -3112,6 +3191,11 @@ func (c *Collection) Update(selector interface{}, update interface{}) error {
 // See the Update method for more details.
 func (c *Collection) UpdateId(id interface{}, update interface{}) error {
 	return c.Update(bson.D{{Name: "_id", Value: id}}, update)
+}
+
+// UpdateIDTransaction calls UpdateId using a transaction.  See UpdateId()
+func (c *Collection) UpdateIdTransaction(t *Transaction, id interface{}, update interface{}) error {
+	return c.UpdateTransaction(t, bson.D{{Name: "_id", Value: id}}, update)
 }
 
 // UpdateWithArrayFilters allows passing an array of filter documents that determines
@@ -3164,7 +3248,13 @@ type ChangeInfo struct {
 //     http://www.mongodb.org/display/DOCS/Updating
 //     http://www.mongodb.org/display/DOCS/Atomic+Operations
 //
+
 func (c *Collection) UpdateAll(selector interface{}, update interface{}) (info *ChangeInfo, err error) {
+	return c.UpdateAllTransaction(nil, selector, update)
+}
+
+// UpdateAllTransaction is UpdateAll using a transaction.  See UpdateAll().
+func (c *Collection) UpdateAllTransaction(t *Transaction, selector interface{}, update interface{}) (info *ChangeInfo, err error) {
 	if selector == nil {
 		selector = bson.D{}
 	}
@@ -3174,6 +3264,7 @@ func (c *Collection) UpdateAll(selector interface{}, update interface{}) (info *
 		Update:     update,
 		Flags:      2,
 		Multi:      true,
+		Txn:        t,
 	}
 	lerr, err := c.writeOp(&op, true)
 	if err == nil && lerr != nil {
@@ -3196,6 +3287,11 @@ func (c *Collection) UpdateAll(selector interface{}, update interface{}) (info *
 //     http://www.mongodb.org/display/DOCS/Atomic+Operations
 //
 func (c *Collection) Upsert(selector interface{}, update interface{}) (info *ChangeInfo, err error) {
+	return c.UpsertTransaction(nil, selector, update)
+}
+
+// UpsertTransaction upserts using a transaction.  See Upsert()
+func (c *Collection) UpsertTransaction(t *Transaction, selector interface{}, update interface{}) (info *ChangeInfo, err error) {
 	if selector == nil {
 		selector = bson.D{}
 	}
@@ -3205,6 +3301,7 @@ func (c *Collection) Upsert(selector interface{}, update interface{}) (info *Cha
 		Update:     update,
 		Flags:      1,
 		Upsert:     true,
+		Txn:        t,
 	}
 	var lerr *LastError
 	for i := 0; i < maxUpsertRetries; i++ {
@@ -3236,6 +3333,11 @@ func (c *Collection) UpsertId(id interface{}, update interface{}) (info *ChangeI
 	return c.Upsert(bson.D{{Name: "_id", Value: id}}, update)
 }
 
+// UpsertIdTransaction is UpsertId with transaction support.  See UpsertId().
+func (c *Collection) UpsertIdTransaction(t *Transaction, id interface{}, update interface{}) (info *ChangeInfo, err error) {
+	return c.UpsertTransaction(t, bson.D{{Name: "_id", Value: id}}, update)
+}
+
 // Remove finds a single document matching the provided selector document
 // and removes it from the database.
 // If the session is in safe mode (see SetSafe) a ErrNotFound error is
@@ -3247,10 +3349,15 @@ func (c *Collection) UpsertId(id interface{}, update interface{}) (info *ChangeI
 //     http://www.mongodb.org/display/DOCS/Removing
 //
 func (c *Collection) Remove(selector interface{}) error {
+	return c.RemoveTransaction(nil, selector)
+}
+
+// RemoveTransaction is Remove with transaction support.  See Remove()
+func (c *Collection) RemoveTransaction(t *Transaction, selector interface{}) error {
 	if selector == nil {
 		selector = bson.D{}
 	}
-	lerr, err := c.writeOp(&deleteOp{c.FullName, selector, 1, 1}, true)
+	lerr, err := c.writeOp(&deleteOp{c.FullName, selector, 1, 1, t}, true)
 	if err == nil && lerr != nil && lerr.N == 0 {
 		return ErrNotFound
 	}
@@ -3266,6 +3373,11 @@ func (c *Collection) RemoveId(id interface{}) error {
 	return c.Remove(bson.D{{Name: "_id", Value: id}})
 }
 
+// RemoveIdTransaction is RemoveId with transaction support.  See RemoveId().
+func (c *Collection) RemoveIdTransaction(t *Transaction, id interface{}) error {
+	return c.RemoveTransaction(t, bson.D{{Name: "_id", Value: id}})
+}
+
 // RemoveAll finds all documents matching the provided selector document
 // and removes them from the database.  In case the session is in safe mode
 // (see the SetSafe method) and an error happens when attempting the change,
@@ -3276,10 +3388,15 @@ func (c *Collection) RemoveId(id interface{}) error {
 //     http://www.mongodb.org/display/DOCS/Removing
 //
 func (c *Collection) RemoveAll(selector interface{}) (info *ChangeInfo, err error) {
+	return c.RemoveAllTransaction(nil, selector)
+}
+
+// RemoveAllTransaction is RemoveAll with transaction support.  see RemoveAll().
+func (c *Collection) RemoveAllTransaction(t *Transaction, selector interface{}) (info *ChangeInfo, err error) {
 	if selector == nil {
 		selector = bson.D{}
 	}
-	lerr, err := c.writeOp(&deleteOp{c.FullName, selector, 0, 0}, true)
+	lerr, err := c.writeOp(&deleteOp{c.FullName, selector, 0, 0, t}, true)
 	if err == nil && lerr != nil {
 		info = &ChangeInfo{Removed: lerr.N, Matched: lerr.N}
 	}
@@ -3372,7 +3489,14 @@ func (c *Collection) Create(info *CollectionInfo) error {
 			cmd = append(cmd, bson.DocElem{Name: "max", Value: info.MaxDocs})
 		}
 	}
-	if info.DisableIdIndex {
+
+	b, err := c.Database.Session.BuildInfo()
+	if err != nil {
+		return err
+	}
+	if b.VersionAtLeast(4, 0) {
+		logf("Cannot Disable ID Index above version 4.0")
+	} else if info.DisableIdIndex {
 		cmd = append(cmd, bson.DocElem{Name: "autoIndexId", Value: false})
 	}
 	if info.ForceIdIndex {
@@ -3732,6 +3856,11 @@ func (q *Query) SetMaxTime(d time.Duration) *Query {
 //     http://www.mongodb.org/display/DOCS/How+to+do+Snapshotted+Queries+in+the+Mongo+Database
 //
 func (q *Query) Snapshot() *Query {
+	// snapshots in a find are removed in 4.0 and later
+	b, _ := q.session.BuildInfo()
+	if b.VersionAtLeast(4, 0) {
+		return q
+	}
 	q.m.Lock()
 	q.op.options.Snapshot = true
 	q.op.hasOptions = true
@@ -4144,6 +4273,11 @@ func (db *Database) CollectionNames() (names []string, err error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+type sessionResult struct {
+	ID             interface{} `bson:"id"`
+	TimeoutMinutes string      `bson:"timeoutMinutes"`
 }
 
 type dbNames struct {
@@ -5636,16 +5770,56 @@ func (c *Collection) writeOpCommand(socket *mongoSocket, safeOp *queryOp, op int
 		cmd = bson.D{
 			{Name: "insert", Value: c.Name},
 			{Name: "documents", Value: op.documents},
-			{Name: "writeConcern", Value: writeConcern},
 			{Name: "ordered", Value: op.flags&1 == 0},
+		}
+		if op.txn != nil {
+			if op.txn.finished == true {
+				err := errors.New("transaction already completed")
+				return nil, err
+			}
+			if op.txn.session.SessionID.Kind == 0 {
+				err := errors.New("session not started")
+				return nil, err
+			}
+			if op.txn.started == false {
+				cmd = append(cmd, bson.DocElem{Name: "startTransaction", Value: true})
+				op.txn.txnNumber = op.txn.session.nextTxnNumber
+				op.txn.session.nextTxnNumber++
+				op.txn.started = true
+			}
+			cmd = append(cmd, bson.DocElem{Name: "autocommit", Value: false})
+			cmd = append(cmd, bson.DocElem{Name: "txnNumber", Value: op.txn.txnNumber})
+			cmd = append(cmd, bson.DocElem{Name: "lsid", Value: bson.M{"id": op.txn.session.SessionID}})
+		} else {
+			cmd = append(cmd, bson.DocElem{Name: "writeConcern", Value: writeConcern})
 		}
 	case *updateOp:
 		// http://docs.mongodb.org/manual/reference/command/update
 		cmd = bson.D{
 			{Name: "update", Value: c.Name},
 			{Name: "updates", Value: []interface{}{op}},
-			{Name: "writeConcern", Value: writeConcern},
 			{Name: "ordered", Value: ordered},
+		}
+		if op.Txn != nil {
+			if op.Txn.finished == true {
+				err := errors.New("transaction already completed")
+				return nil, err
+			}
+			if op.Txn.session.SessionID.Kind == 0 {
+				err := errors.New("session not started")
+				return nil, err
+			}
+			if op.Txn.started == false {
+				cmd = append(cmd, bson.DocElem{Name: "startTransaction", Value: true})
+				op.Txn.started = true
+				op.Txn.txnNumber = op.Txn.session.nextTxnNumber
+				op.Txn.session.nextTxnNumber++
+			}
+			cmd = append(cmd, bson.DocElem{Name: "autocommit", Value: false})
+			cmd = append(cmd, bson.DocElem{Name: "txnNumber", Value: op.Txn.txnNumber})
+			cmd = append(cmd, bson.DocElem{Name: "lsid", Value: bson.M{"id": op.Txn.session.SessionID}})
+		} else {
+			cmd = append(cmd, bson.DocElem{Name: "writeConcern", Value: writeConcern})
 		}
 	case bulkUpdateOp:
 		// http://docs.mongodb.org/manual/reference/command/update
@@ -5660,8 +5834,28 @@ func (c *Collection) writeOpCommand(socket *mongoSocket, safeOp *queryOp, op int
 		cmd = bson.D{
 			{Name: "delete", Value: c.Name},
 			{Name: "deletes", Value: []interface{}{op}},
-			{Name: "writeConcern", Value: writeConcern},
 			{Name: "ordered", Value: ordered},
+		}
+		if op.Txn != nil {
+			if op.Txn.finished == true {
+				err := errors.New("transaction already completed")
+				return nil, err
+			}
+			if op.Txn.session.SessionID.Kind == 0 {
+				err := errors.New("session not started")
+				return nil, err
+			}
+			if op.Txn.started == false {
+				cmd = append(cmd, bson.DocElem{Name: "startTransaction", Value: true})
+				op.Txn.started = true
+				op.Txn.txnNumber = op.Txn.session.nextTxnNumber
+				op.Txn.session.nextTxnNumber++
+			}
+			cmd = append(cmd, bson.DocElem{Name: "autocommit", Value: false})
+			cmd = append(cmd, bson.DocElem{Name: "txnNumber", Value: op.Txn.txnNumber})
+			cmd = append(cmd, bson.DocElem{Name: "lsid", Value: bson.M{"id": op.Txn.session.SessionID}})
+		} else {
+			cmd = append(cmd, bson.DocElem{Name: "writeConcern", Value: writeConcern})
 		}
 	case bulkDeleteOp:
 		// http://docs.mongodb.org/manual/reference/command/delete

--- a/session.go
+++ b/session.go
@@ -108,6 +108,8 @@ type Session struct {
 	queryConfig      query
 	bypassValidation bool
 	slaveOk          bool
+	SessionID        bson.Binary
+	nextTxnNumber    int64
 
 	dialInfo *DialInfo
 }

--- a/session_test.go
+++ b/session_test.go
@@ -440,6 +440,42 @@ func (s *S) TestInsertFindOne(c *C) {
 	c.Assert(result.B, Equals, 3)
 }
 
+func (s *S) TestInsertFindOneTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40011")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+	tr := mgo.NewTransaction(session)
+
+	coll := session.DB("mydb").C("mycoll")
+
+	// insert a dummy so we're not trying to create the collection
+	// in a multi-document transaction
+	err = coll.Insert(M{"dummy": 1})
+	err = coll.InsertTransaction(&tr, M{"a": 1, "b": 2})
+	c.Assert(err, IsNil)
+	err = coll.InsertTransaction(&tr, M{"a": 1, "b": 3})
+	c.Assert(err, IsNil)
+
+	result := struct{ A, B int }{}
+
+	err = coll.Find(M{"a": 1}).Sort("b").One(&result)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+
+	tr.Commit()
+
+	err = coll.Find(M{"a": 1}).Sort("b").One(&result)
+	c.Assert(err, IsNil)
+	c.Assert(result.A, Equals, 1)
+	c.Assert(result.B, Equals, 2)
+
+	err = coll.Find(M{"a": 1}).Sort("-b").One(&result)
+	c.Assert(err, IsNil)
+	c.Assert(result.A, Equals, 1)
+	c.Assert(result.B, Equals, 3)
+}
+
 func (s *S) TestInsertFindOneNil(c *C) {
 	session, err := mgo.Dial("localhost:40002")
 	c.Assert(err, IsNil)
@@ -683,6 +719,76 @@ func (s *S) TestUpdate(c *C) {
 	c.Assert(err, Equals, mgo.ErrNotFound)
 }
 
+func (s *S) TestUpdateWithCompletedTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40011")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+
+	tr := mgo.NewTransaction(session)
+	coll := session.DB("mydb").C("mycoll")
+
+	ns := []int{40, 41, 42, 43, 44, 45, 46}
+	for _, n := range ns {
+		err := coll.Insert(M{"k": n, "n": n})
+		c.Assert(err, IsNil)
+	}
+
+	// No changes is a no-op and shouldn't return an error.
+	err = coll.UpdateTransaction(&tr, M{"k": 42}, M{"$set": M{"n": 42}})
+	c.Assert(err, IsNil)
+
+	err = coll.UpdateTransaction(&tr, M{"k": 42}, M{"$inc": M{"n": 1}})
+	c.Assert(err, IsNil)
+
+	result := make(M)
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 42)
+
+	tr.Commit()
+
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 43)
+}
+
+func (s *S) TestUpdateWithAbortedTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40011")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+
+	tr := mgo.NewTransaction(session)
+	coll := session.DB("mydb").C("mycoll")
+
+	ns := []int{40, 41, 42, 43, 44, 45, 46}
+	for _, n := range ns {
+		err := coll.Insert(tr, M{"k": n, "n": n})
+		c.Assert(err, IsNil)
+	}
+
+	// No changes is a no-op and shouldn't return an error.
+	err = coll.UpdateTransaction(&tr, M{"k": 42}, M{"$set": M{"n": 42}})
+	c.Assert(err, IsNil)
+
+	err = coll.UpdateTransaction(&tr, M{"k": 42}, M{"$inc": M{"n": 1}})
+	c.Assert(err, IsNil)
+
+	result := make(M)
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 42)
+
+	tr.Abort()
+
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 42)
+}
+
 func (s *S) TestUpdateId(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
@@ -700,6 +806,43 @@ func (s *S) TestUpdateId(c *C) {
 	c.Assert(err, IsNil)
 
 	result := make(M)
+	err = coll.FindId(42).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 43)
+
+	err = coll.UpdateId(47, M{"k": 47, "n": 47})
+	c.Assert(err, Equals, mgo.ErrNotFound)
+
+	err = coll.FindId(47).One(result)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+}
+
+func (s *S) TestUpdateIdTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+
+	coll := session.DB("mydb").C("mycoll")
+	tr := mgo.NewTransaction(session)
+
+	ns := []int{40, 41, 42, 43, 44, 45, 46}
+	for _, n := range ns {
+		err := coll.Insert(M{"_id": n, "n": n})
+		c.Assert(err, IsNil)
+	}
+
+	err = coll.UpdateIdTransaction(&tr, 42, M{"$inc": M{"n": 1}})
+	c.Assert(err, IsNil)
+
+	result := make(M)
+
+	err = coll.FindId(42).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 42)
+
+	tr.Commit()
 	err = coll.FindId(42).One(result)
 	c.Assert(err, IsNil)
 	c.Assert(result["n"], Equals, 43)
@@ -886,6 +1029,39 @@ func (s *S) TestUpsert(c *C) {
 	c.Assert(result["n"], Equals, 48)
 }
 
+func (s *S) TestUpsertTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40011")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+	tr := mgo.NewTransaction(session)
+	coll := session.DB("mydb").C("mycoll")
+
+	ns := []int{40, 41, 42, 43, 44, 45, 46}
+	for _, n := range ns {
+		err := coll.Insert(bson.D{{Name: "k", Value: n}, {Name: "n", Value: n}})
+		c.Assert(err, IsNil)
+	}
+
+	info, err := coll.UpsertTransaction(&tr, M{"k": 42}, bson.D{{Name: "k", Value: 42}, {Name: "n", Value: 24}})
+	c.Assert(err, IsNil)
+	c.Assert(info.Updated, Equals, 1)
+	c.Assert(info.Matched, Equals, 1)
+	c.Assert(info.UpsertedId, IsNil)
+
+	result := M{}
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 42)
+
+	tr.Commit()
+
+	err = coll.Find(M{"k": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result["n"], Equals, 24)
+}
+
 func (s *S) TestUpsertId(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
@@ -974,6 +1150,47 @@ func (s *S) TestRemove(c *C) {
 	c.Assert(err, IsNil)
 
 	result := &struct{ N int }{}
+	err = coll.Find(M{"n": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result.N, Equals, 42)
+
+	err = coll.Find(M{"n": 43}).One(result)
+	c.Assert(err, Equals, mgo.ErrNotFound)
+
+	err = coll.Find(M{"n": 44}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result.N, Equals, 44)
+}
+
+func (s *S) TestRemoveTransaction(c *C) {
+	session, err := mgo.Dial("localhost:40011")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.Start()
+	tr := mgo.NewTransaction(session)
+
+	coll := session.DB("mydb").C("mycoll")
+
+	ns := []int{40, 41, 42, 43, 44, 45, 46}
+	for _, n := range ns {
+		err := coll.Insert(M{"n": n})
+		c.Assert(err, IsNil)
+	}
+
+	err = coll.RemoveTransaction(&tr, M{"n": M{"$gt": 42}})
+	c.Assert(err, IsNil)
+
+	result := &struct{ N int }{}
+	err = coll.Find(M{"n": 42}).One(result)
+	c.Assert(err, IsNil)
+	c.Assert(result.N, Equals, 42)
+
+	err = coll.Find(M{"n": 43}).One(result)
+	c.Assert(result.N, Equals, 43)
+
+	tr.Commit()
+
 	err = coll.Find(M{"n": 42}).One(result)
 	c.Assert(err, IsNil)
 	c.Assert(result.N, Equals, 42)
@@ -1178,8 +1395,9 @@ func (s *S) TestCreateCollectionNoIndex(c *C) {
 	err = coll.Insert(M{"n": 1})
 	c.Assert(err, IsNil)
 
-	indexes, err := coll.Indexes()
-	c.Assert(indexes, HasLen, 0)
+	// Removing this test.  After 4.0, you can't disable indexes.
+	// indexes, err := coll.Indexes()
+	//c.Assert(indexes, HasLen, 0)
 }
 
 func (s *S) TestCreateCollectionForceIndex(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -441,6 +441,9 @@ func (s *S) TestInsertFindOne(c *C) {
 }
 
 func (s *S) TestInsertFindOneTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40011")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -720,6 +723,9 @@ func (s *S) TestUpdate(c *C) {
 }
 
 func (s *S) TestUpdateWithCompletedTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40011")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -755,6 +761,9 @@ func (s *S) TestUpdateWithCompletedTransaction(c *C) {
 }
 
 func (s *S) TestUpdateWithAbortedTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40011")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -818,6 +827,9 @@ func (s *S) TestUpdateId(c *C) {
 }
 
 func (s *S) TestUpdateIdTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -1030,6 +1042,9 @@ func (s *S) TestUpsert(c *C) {
 }
 
 func (s *S) TestUpsertTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40011")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -1163,6 +1178,9 @@ func (s *S) TestRemove(c *C) {
 }
 
 func (s *S) TestRemoveTransaction(c *C) {
+	if !s.versionAtLeast(4, 0) {
+		c.Skip("Transactions not supported before MongoDB 4.0")
+	}
 	session, err := mgo.Dial("localhost:40011")
 	c.Assert(err, IsNil)
 	defer session.Close()

--- a/socket.go
+++ b/socket.go
@@ -157,23 +157,26 @@ type insertOp struct {
 	collection string        // "database.collection"
 	documents  []interface{} // One or more documents to insert
 	flags      uint32
+	txn        *Transaction
 }
 
 type updateOp struct {
-	Collection   string      `bson:"-"` // "database.collection"
-	Selector     interface{} `bson:"q"`
-	Update       interface{} `bson:"u"`
-	Flags        uint32      `bson:"-"`
-	Multi        bool        `bson:"multi,omitempty"`
-	Upsert       bool        `bson:"upsert,omitempty"`
-	ArrayFilters interface{} `bson:"arrayFilters,omitempty"`
+	Collection   string       `bson:"-"` // "database.collection"
+	Selector     interface{}  `bson:"q"`
+	Update       interface{}  `bson:"u"`
+	Flags        uint32       `bson:"-"`
+	Multi        bool         `bson:"multi,omitempty"`
+	Upsert       bool         `bson:"upsert,omitempty"`
+	ArrayFilters interface{}  `bson:"arrayFilters,omitempty"`
+	Txn          *Transaction `bson:"-"`
 }
 
 type deleteOp struct {
-	Collection string      `bson:"-"` // "database.collection"
-	Selector   interface{} `bson:"q"`
-	Flags      uint32      `bson:"-"`
-	Limit      int         `bson:"limit"`
+	Collection string       `bson:"-"` // "database.collection"
+	Selector   interface{}  `bson:"q"`
+	Flags      uint32       `bson:"-"`
+	Limit      int          `bson:"limit"`
+	Txn        *Transaction `bson:"-"`
 }
 
 type killCursorsOp struct {

--- a/suite_test.go
+++ b/suite_test.go
@@ -144,6 +144,8 @@ func (s *S) Stop(host string) {
 	panicOnWindows()
 	time.Sleep(2 * time.Second)
 	err := run("svc -d _harness/daemons/" + supvName(host))
+	// Give a moment to allow the host to stop, svc returns immediately
+	time.Sleep(5 * time.Second)
 	if err != nil {
 		panic(err)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,1 @@
+package mgo

--- a/transaction.go
+++ b/transaction.go
@@ -1,4 +1,5 @@
 package mgo
+
 // mgo - MongoDB driver for Go
 //
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
@@ -25,8 +26,6 @@ package mgo
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-package mgo
 
 // The transaction struct is only initialized with a valid Session, and that does not
 // change.  The struct contains state information for the transaction.  The transaction

--- a/transaction.go
+++ b/transaction.go
@@ -1,1 +1,65 @@
 package mgo
+// mgo - MongoDB driver for Go
+//
+// Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
+// transaction.go (c) 2018 Russell Miller/The Home Depot <russell_j_miller@homedepot.com>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package mgo
+
+// The transaction struct is only initialized with a valid Session, and that does not
+// change.  The struct contains state information for the transaction.  The transaction
+// is started when the first write operation is created using it, and it is finished when
+// it is either committed or aborted.  If the session is killed out from under it, of
+// course, it will be left in an inconsistent state, but the transaction will be dead and
+// presumably already aborted.
+type Transaction struct {
+	session   *Session
+	started   bool
+	finished  bool
+	txnNumber int64
+}
+
+// NewTransaction creates a new Transaction object.
+func NewTransaction(s *Session) Transaction {
+	return Transaction{
+		session: s,
+	}
+}
+
+// Commit commits and finalizes the transaction.
+func (t *Transaction) Commit() error {
+	// check errors
+	err := t.session.CommitTransaction(t.txnNumber)
+	t.finished = true
+	return err
+}
+
+// Abort aborts and closes the transaction.
+func (t *Transaction) Abort() error {
+	// check errors
+	err := t.session.AbortTransaction(t.txnNumber)
+	t.finished = true
+	return err
+}


### PR DESCRIPTION
Third time's a charm!  I think we did it right this time.

This time, I pulled the latest version of development and ported my changes into that.  This contains the following changes:

1)  Partial 4.0 transaction support.  This supports the basic Update, Upsert, Remove, and Insert support.  Batch support is not included (but could probably easily be added - it's not a use case we needed at the moment).
2)  dbtest supports creating a replica set now.  You have to explicitly enable that.
3)  A few other minor bugs and issues fixed.

Documentation is included in the repo.

All changes are, to the best of my knowledge, backwards compatible.  All tests pass for me with the exception of some clustering tests that may be related to 4.0 but are not related to my changes to the best of my knowledge.

We at The Home Depot are excited to be sharing these changes with the community, please let me know if there are further issues that need to be addressed.