### PR TITLE
Fix import path for golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     - go get gopkg.in/check.v1
     - go get gopkg.in/yaml.v2
     - go get gopkg.in/tomb.v2
-    - go get github.com/golang/lint
+    - go get golang.org/x/lint/golint
 
 before_script:
     - golint  ./... | grep -v 'ID' | cat


### PR DESCRIPTION
CI seems to be failing because `go get github.com/golant/lint` is not working anymore; the problem appears to be that the package should be imported from `golant.org/x/lint/golint` instead. See https://github.com/golang/lint/issues/419