### PR TITLE
Allow configurable load balancing strategies, add a uniformRandom

### DIFF
--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ package mgo
 
 import (
 	"errors"
+	"math/rand"
 	"net"
 	"sort"
 	"sync"
@@ -555,6 +556,14 @@ func (servers *mongoServers) HasMongos() bool {
 		}
 	}
 	return false
+}
+
+// Picks servers uniform at random to perform operations on. Mainly used when
+// all the seed servers are mongos and we want to distribute load evenly
+func (servers *mongoServers) UniformRandom() *mongoServer {
+	var best *mongoServer
+	best = servers.slice[rand.Int31n(int32(len(servers.slice)))]
+	return best
 }
 
 // BestFit returns the best guess of what would be the most interesting

--- a/session.go
+++ b/session.go
@@ -494,6 +494,9 @@ type DialInfo struct {
 	// to be established. Timeout does not affect logic in DialServer.
 	Timeout time.Duration
 
+	// Which load balancing strategy to use when selecting a server to do
+	// an operation on
+	LoadBalancingStrategy LoadBalancingStrategy
 	// Database is the default database name used when the Session.DB method
 	// is called with an empty name, and is also used during the initial
 	// authentication if Source is unset.


### PR DESCRIPTION
strategy

Useful for when talking to mongoS instead of a cluster of mongoD's directly. The BestFit algorithm will form hotspots on particular mongoS when we want to share the load across all mongos that we are connected to