### PR TITLE
Don't panic when an index with a bad value is found in Indexes().

### DIFF
--- a/session_internal_test.go
+++ b/session_internal_test.go
@@ -28,7 +28,25 @@ func TestIndexedInt64FieldsBug(t *testing.T) {
 		{Name: "testkey", Value: float64(1)},
 	}
 
-	_ = simpleIndexKey(input)
+	indexes, err := simpleIndexKey(input)
+	if err != nil {
+		t.Error("Received unexpected error: ", err)
+	}
+	if len(input) != len(indexes) {
+		t.Errorf("Expected %d indexes returned; received %d\n", len(input), len(indexes))
+	}
+}
+
+// Ensures we don't panic (but do return an error) with bad index sort types
+func TestIndexedUnknownTypeErr(t *testing.T) {
+	input := bson.D{
+		{Name: "testkey", Value: bool(false)},
+	}
+
+	_, err := simpleIndexKey(input)
+	if err == nil {
+		t.Error("Expected an error for unknown index value type (bool) but none received")
+	}
 }
 
 func (s *S) TestGetRFC2253NameStringSingleValued(c *C) {


### PR DESCRIPTION
Instead, return an error and let the consumer decide how to proceed.

In practice, I've come across a fair amount of DBs in the wild that exhibit this problem.
To replicate locally, I had to do a `mongodump`, edit the index metadata, and do a `mongorestore` *into a 2.6.X DB*. More modern versions of mongo prevent it from happening, but the reality is there's junk in the wild.

Panicing in this case makes us refactor consumer code to defer and recover, which could just be an error check instead.