### PR TITLE
invalid objectid: add field name and real value as message

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -790,8 +790,10 @@ type structWithDupKeys struct {
 var marshalErrorItems = []testItemType{
 	{bson.M{"": uint64(1 << 63)},
 		"BSON has no uint64 type, and value is too large to fit correctly in an int64"},
-	{bson.M{"": bson.ObjectId("tooshort")},
-		"ObjectIDs must be exactly 12 bytes long \\(got 8\\)"},
+	{bson.M{"key": bson.ObjectId("tooshort")},
+		"ObjectIDs\\(key\\) must be exactly 12 bytes long \\(got \"tooshort\"\\)"},
+	{bson.M{"key": bson.DBPointer{Namespace: "", Id: bson.ObjectId("tooshort")}},
+		"ObjectIDs\\(key\\.id\\) must be exactly 12 bytes long \\(got \"tooshort\"\\)"},
 	{int64(123),
 		"Can't marshal int64 as a BSON document"},
 	{bson.M{"": 1i},

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -380,8 +380,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 		switch v.Type() {
 		case typeObjectId:
 			if len(s) != 12 {
-				panic("ObjectIDs must be exactly 12 bytes long (got " +
-					strconv.Itoa(len(s)) + ")")
+				panic(fmt.Sprintf("ObjectIDs(%s) must be exactly 12 bytes long (got \"%s\")", name, s))
 			}
 			e.addElemName(0x07, name)
 			e.addBytes([]byte(s)...)
@@ -532,8 +531,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			e.addElemName(0x0C, name)
 			e.addStr(s.Namespace)
 			if len(s.Id) != 12 {
-				panic("ObjectIDs must be exactly 12 bytes long (got " +
-					strconv.Itoa(len(s.Id)) + ")")
+				panic(fmt.Sprintf("ObjectIDs(%s.id) must be exactly 12 bytes long (got \"%s\")", name, string(s.Id)))
 			}
 			e.addBytes([]byte(s.Id)...)
 


### PR DESCRIPTION
when insert/update an objectid filed, if invalid id passed, the error message will be: `ObjectIDs must be exactly 12 bytes long (got 0)`.

the error message cannot help developer to fingure out the field name.