### PR TITLE
Remove operations pull completed tokens from txn-queue

### DIFF
--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -708,7 +708,7 @@ func (f *flusher) abortOrReload(t *transaction, revnos []int64, pull map[bson.Ob
 			}
 			seen[dkey] = true
 
-			pullAll := tokensToPull(f.queue[dkey], pull, "")
+			pullAll, _ := tokensToPull(f.queue[dkey], pull, "")
 			if len(pullAll) == 0 {
 				continue
 			}
@@ -803,7 +803,7 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 			qdoc[1].Value = bson.D{{Name: "$exists", Value: false}}
 		}
 
-		pullAll := tokensToPull(dqueue, pull, tt)
+		pullAll, pulledQueue := tokensToPull(dqueue, pull, tt)
 
 		var d bson.D
 		var outcome string
@@ -859,10 +859,10 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 						var set, unset bson.D
 						if revno == 0 {
 							// Missing revno in stash means -1.
-							set = bson.D{{Name: "txn-queue", Value: info.Queue}}
+							set = bson.D{{Name: "txn-queue", Value: pulledQueue}}
 							unset = bson.D{{Name: "n", Value: 1}, {Name: "txn-revno", Value: 1}}
 						} else {
-							set = bson.D{{Name: "txn-queue", Value: info.Queue}, {Name: "txn-revno", Value: newRevno}}
+							set = bson.D{{Name: "txn-queue", Value: pulledQueue}, {Name: "txn-revno", Value: newRevno}}
 							unset = bson.D{{Name: "n", Value: 1}}
 						}
 						qdoc := bson.D{{Name: "_id", Value: dkey}, {Name: "n", Value: nonce}}
@@ -898,6 +898,7 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 				var info txnInfo
 				if _, err = f.sc.Find(qdoc).Apply(change, &info); err == nil {
 					f.debugf("Stash for document %v has revno %d and queue: %v", dkey, info.Revno, info.Queue)
+					// TODO(jam): 2018-11-19 should we also go through tokensToPull here?
 					d = setInDoc(d, bson.D{{Name: "_id", Value: op.Id}, {Name: "txn-revno", Value: newRevno}, {Name: "txn-queue", Value: info.Queue}})
 					// Unlikely yet unfortunate race in here if this gets seriously
 					// delayed. If someone inserts+removes meanwhile, this will
@@ -982,20 +983,24 @@ func (f *flusher) apply(t *transaction, pull map[bson.ObjectId]*transaction) err
 	return nil
 }
 
-func tokensToPull(dqueue []tokenAndId, pull map[bson.ObjectId]*transaction, dontPull token) []token {
-	var result []token
+func tokensToPull(dqueue []tokenAndId, pull map[bson.ObjectId]*transaction, dontPull token) ([]token, []token) {
+	var pullAll []token
+	var pulledQueue []token
 	for j := len(dqueue) - 1; j >= 0; j-- {
 		dtt := dqueue[j]
 		if dtt.tt == dontPull {
+			pulledQueue = append(pulledQueue, dtt.tt)
 			continue
 		}
 		if _, ok := pull[dtt.Id()]; ok {
 			// It was handled before and this is a leftover invalid
 			// nonce in the queue. Cherry-pick it out.
-			result = append(result, dtt.tt)
+			pullAll = append(pullAll, dtt.tt)
+		} else {
+			pulledQueue = append(pulledQueue, dtt.tt)
 		}
 	}
-	return result
+	return pullAll, pulledQueue
 }
 
 func objToDoc(obj interface{}) (d bson.D, err error) {

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -1098,7 +1098,6 @@ func (s *S) TestTxnQueueAddAndRemove(c *C) {
 	c.Assert(err, IsNil)
 	err = s.accounts.FindId(0).One(&qdoc)
 	c.Assert(err, IsNil)
-	// Remove prunes the txn-queue but Insert currently does not, so we end up with the last Remove
-	// and the last Insert in the document.
-	c.Check(len(qdoc.Queue), Equals, 2)
+	// Both Remove and Insert should prune all the completed transactions
+	c.Check(len(qdoc.Queue), Equals, 1)
 }

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -18,6 +18,8 @@ func TestAll(t *testing.T) {
 	TestingT(t)
 }
 
+var fast = flag.Bool("fast", false, "Skip slow tests")
+
 type S struct {
 	server   dbtest.DBServer
 	session  *mgo.Session
@@ -578,6 +580,9 @@ func (s *S) TestPurgeMissing(c *C) {
 }
 
 func (s *S) TestTxnQueueStashStressTest(c *C) {
+	if *fast {
+		c.Skip("-fast was supplied and this test is slow")
+	}
 	txn.SetChaos(txn.Chaos{
 		SlowdownChance: 0.3,
 		Slowdown:       50 * time.Millisecond,

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -1096,8 +1096,6 @@ func (s *S) TestTxnQueueAddAndRemove(c *C) {
 	var qdoc txnQueue
 	err = s.accounts.FindId(0).One(&qdoc)
 	c.Assert(err, IsNil)
-	err = s.accounts.FindId(0).One(&qdoc)
-	c.Assert(err, IsNil)
 	// Both Remove and Insert should prune all the completed transactions
 	c.Check(len(qdoc.Queue), Equals, 1)
 }


### PR DESCRIPTION
We ran into an odd edge case in our system, where we had a document that was being created and then removed repeatedly. (People were testing if the system worked by creating an object and then immediately removing it.)

The code for Insert and Remove just copies whatever the txn-queue was from the collection to the stash and back. This changes it so that both clean up the txn-queue while it is creating the document in the stash. This should be functionally equivalent to the `$pullAll` that we do during Update. It should be safe to do this because we are expressly creating the document out of 'whole cloth' with an Insert, so it isn't possible for us to be racing with another thread that is trying to add another txn to the queue. (If it was, this doesn't change the race that we would have already had).

There is an extra pass over the freshly read txn-queue, but in well behaved systems, the queue should always be kept small. This is mostly a case where we found we *weren't* behaving well.