### PR TITLE
Ensure resources released on errors

### DIFF
--- a/changestreams.go
+++ b/changestreams.go
@@ -259,6 +259,7 @@ func (changeStream *ChangeStream) resume() error {
 	cursorId := changeStream.iter.op.cursorId
 	err := runKillCursorsOnSession(newSession, cursorId)
 	if err != nil {
+		newSession.Close()
 		return err
 	}
 
@@ -347,11 +348,6 @@ func runKillCursorsOnSession(session *Session, cursorId int64) error {
 	if err != nil {
 		return err
 	}
-	err = socket.Query(&killCursorsOp{[]int64{cursorId}})
-	if err != nil {
-		return err
-	}
-	socket.Release()
-
-	return nil
+	defer socket.Release()
+	return socket.Query(&killCursorsOp{[]int64{cursorId}})
 }


### PR DESCRIPTION
This commit ensures some Close() and Release() calls are performed when errors are encountered.  