### PR TITLE
Change stream enhancements

### DIFF
--- a/changestreams.go
+++ b/changestreams.go
@@ -254,7 +254,9 @@ func (changeStream *ChangeStream) Next(result interface{}) bool {
 	// try to fetch the next result.
 	err = changeStream.fetchResultSet(result)
 	if err != nil {
-		changeStream.err = err
+		if err != ErrNotFound {
+			changeStream.err = err
+		}
 		return false
 	}
 

--- a/changestreams.go
+++ b/changestreams.go
@@ -358,6 +358,14 @@ func (changeStream *ChangeStream) resume() error {
 		newPipe = changeStream.database.pipe(changeStreamPipeline)
 	}
 
+	// apply any options set to the new pipe
+	if opts.MaxAwaitTimeMS > 0 {
+		newPipe.SetMaxTime(opts.MaxAwaitTimeMS)
+	}
+	if opts.BatchSize > 0 {
+		newPipe.Batch(opts.BatchSize)
+	}
+
 	// pipes internally create new socket connnections
 	changeStream.iter = newPipe.Iter()
 	if err := changeStream.iter.Err(); err != nil {

--- a/changestreams.go
+++ b/changestreams.go
@@ -302,10 +302,9 @@ func (changeStream *ChangeStream) ResumeToken() *bson.Raw {
 	return &tokenCopy
 }
 
-// Timeout returns true if the last call of Next returned false because of an iterator timeout
-// or there was no error.
+// Timeout returns true if the last call of Next returned false because of an iterator timeout.
 func (changeStream *ChangeStream) Timeout() bool {
-	return changeStream.iter.Err() == nil || changeStream.iter.Timeout()
+	return changeStream.iter.Timeout()
 }
 
 func constructChangeStreamPipeline(pipeline interface{},

--- a/changestreams.go
+++ b/changestreams.go
@@ -302,9 +302,10 @@ func (changeStream *ChangeStream) ResumeToken() *bson.Raw {
 	return &tokenCopy
 }
 
-// Timeout returns true if the last call of Next returned false because of an iterator timeout.
+// Timeout returns true if the last call of Next returned false because of an iterator timeout
+// or there was no error.
 func (changeStream *ChangeStream) Timeout() bool {
-	return changeStream.iter.Timeout()
+	return changeStream.iter.Err() == nil || changeStream.iter.Timeout()
 }
 
 func constructChangeStreamPipeline(pipeline interface{},

--- a/changestreams.go
+++ b/changestreams.go
@@ -66,6 +66,7 @@ type ChangeStreamOptions struct {
 }
 
 var errMissingResumeToken = errors.New("resume token missing from result")
+var iterTimeout = time.Duration(2) * time.Second
 
 // Watch constructs a new ChangeStream capable of receiving continuing data
 // from the database, it works at collection level.
@@ -93,7 +94,7 @@ func (c *Collection) Watch(pipeline interface{},
 		return nil, err
 	}
 
-	pIter.isChangeStream = true
+	pIter.timeout = iterTimeout
 	return &ChangeStream{
 		iter:        pIter,
 		collection:  c,
@@ -131,7 +132,7 @@ func (sess *Session) Watch(pipeline interface{},
 		return nil, err
 	}
 
-	pIter.isChangeStream = true
+	pIter.timeout = iterTimeout
 	return &ChangeStream{
 		iter:        pIter,
 		resumeToken: nil,
@@ -168,7 +169,7 @@ func (db *Database) Watch(pipeline interface{},
 		return nil, err
 	}
 
-	pIter.isChangeStream = true
+	pIter.timeout = iterTimeout
 	return &ChangeStream{
 		iter:        pIter,
 		resumeToken: nil,
@@ -400,7 +401,7 @@ func (changeStream *ChangeStream) resume() error {
 	if err := changeStream.iter.Err(); err != nil {
 		return err
 	}
-	changeStream.iter.isChangeStream = true
+	changeStream.iter.timeout = iterTimeout
 	return nil
 }
 

--- a/changestreams.go
+++ b/changestreams.go
@@ -338,17 +338,13 @@ func constructChangeStreamPipeline(pipeline interface{},
 
 func (changeStream *ChangeStream) resume() error {
 
-	// Thanks to Copy() future uses will acquire a new socket against the newly selected DB.
-	newSession := changeStream.session.Copy()
-
-	// fetch the cursor from the iterator and use it to run a killCursors
-	// on the connection.
-	cursorId := changeStream.iter.op.cursorId
-	err := runKillCursorsOnSession(newSession, cursorId)
-	if err != nil {
-		newSession.Close()
+	// Close and kill the cursor of the current iterator
+	if err := changeStream.iter.Close(); err != nil {
 		return err
 	}
+
+	// Thanks to Copy() future uses will acquire a new socket against the newly selected DB.
+	newSession := changeStream.session.Copy()
 
 	// Close the session if it has been copied
 	if changeStream.sessionCopied {
@@ -448,13 +444,4 @@ func isResumableError(err error) bool {
 	// but the error is a notMaster error
 	//and is not a missingResumeToken error (caused by the user provided pipeline)
 	return (!isQueryError || isNotMasterError(err)) && (err != errMissingResumeToken)
-}
-
-func runKillCursorsOnSession(session *Session, cursorId int64) error {
-	socket, err := session.acquireSocket(true)
-	if err != nil {
-		return err
-	}
-	defer socket.Release()
-	return socket.Query(&killCursorsOp{[]int64{cursorId}})
 }

--- a/changestreams_test.go
+++ b/changestreams_test.go
@@ -17,12 +17,12 @@ type evNamespace struct {
 }
 
 type changeEvent struct {
-	ID                interface{}         `bson:"_id"`
-	OperationType     string              `bson:"operationType"`
-	FullDocument      *bson.Raw           `bson:"fullDocument,omitempty"`
-	Ns                evNamespace         `bson:"ns"`
-	DocumentKey       M                   `bson:"documentKey"`
-	UpdateDescription *updateDesc         `bson:"updateDescription,omitempty"`
+	ID                interface{} `bson:"_id"`
+	OperationType     string      `bson:"operationType"`
+	FullDocument      *bson.Raw   `bson:"fullDocument,omitempty"`
+	Ns                evNamespace `bson:"ns"`
+	DocumentKey       M           `bson:"documentKey"`
+	UpdateDescription *updateDesc `bson:"updateDescription,omitempty"`
 	ClusterTime       bson.MongoTimestamp `bson:"clusterTime,omitempty"`
 }
 
@@ -508,10 +508,10 @@ func (s *S) TestStreamsUpdateWithPipeline(c *C) {
 		err = coll.Insert(M{"_id": id2, "a": 2})
 		c.Assert(err, IsNil)
 
-		pipeline1 := []M{{"$match": M{"documentKey._id": id1}}}
+		pipeline1 := []M{M{"$match": M{"documentKey._id": id1}}}
 		changeStream1, err := w.Watch(pipeline1, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
 		c.Assert(err, IsNil)
-		pipeline2 := []M{{"$match": M{"documentKey._id": id2}}}
+		pipeline2 := []M{M{"$match": M{"documentKey._id": id2}}}
 		changeStream2, err := w.Watch(pipeline2, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
 		c.Assert(err, IsNil)
 

--- a/changestreams_test.go
+++ b/changestreams_test.go
@@ -17,12 +17,12 @@ type evNamespace struct {
 }
 
 type changeEvent struct {
-	ID                interface{} `bson:"_id"`
-	OperationType     string      `bson:"operationType"`
-	FullDocument      *bson.Raw   `bson:"fullDocument,omitempty"`
-	Ns                evNamespace `bson:"ns"`
-	DocumentKey       M           `bson:"documentKey"`
-	UpdateDescription *updateDesc `bson:"updateDescription,omitempty"`
+	ID                interface{}         `bson:"_id"`
+	OperationType     string              `bson:"operationType"`
+	FullDocument      *bson.Raw           `bson:"fullDocument,omitempty"`
+	Ns                evNamespace         `bson:"ns"`
+	DocumentKey       M                   `bson:"documentKey"`
+	UpdateDescription *updateDesc         `bson:"updateDescription,omitempty"`
 	ClusterTime       bson.MongoTimestamp `bson:"clusterTime,omitempty"`
 }
 
@@ -508,10 +508,10 @@ func (s *S) TestStreamsUpdateWithPipeline(c *C) {
 		err = coll.Insert(M{"_id": id2, "a": 2})
 		c.Assert(err, IsNil)
 
-		pipeline1 := []M{M{"$match": M{"documentKey._id": id1}}}
+		pipeline1 := []M{{"$match": M{"documentKey._id": id1}}}
 		changeStream1, err := w.Watch(pipeline1, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
 		c.Assert(err, IsNil)
-		pipeline2 := []M{M{"$match": M{"documentKey._id": id2}}}
+		pipeline2 := []M{{"$match": M{"documentKey._id": id2}}}
 		changeStream2, err := w.Watch(pipeline2, mgo.ChangeStreamOptions{MaxAwaitTimeMS: 1500})
 		c.Assert(err, IsNil)
 

--- a/changestreams_test.go
+++ b/changestreams_test.go
@@ -227,6 +227,9 @@ func (s *S) TestStreamsNextNoEventTimeout(c *C) {
 		c.Assert(changeStream.Err(), IsNil)
 		c.Assert(changeStream.Timeout(), Equals, true)
 
+		err = changeStream.Close()
+		c.Assert(err, IsNil)
+
 		//test the same with default timeout (MaxTimeMS=1000)
 		//create the stream
 		changeStream, err = w.Watch(pipeline, mgo.ChangeStreamOptions{})


### PR DESCRIPTION
This PR includes a set of changes to change streams based on my testing

- Fixes an issue with a stuck change stream by removing special cases (e.g. iter.isChangeStream) and treating the change stream as a wrapper around a normal iterator.  
- Fix the scenario where the iterator returns no results so the changeStream reports a timeout but the soft error on the iterator was not being reset, so the same timeout result happens repeatedly forever without fetching any new results.
- Adds the ability to set the startAtOperationTime option for MongoDB 4.0+
- Fixes some of the logic so that it is consistent across all change domains.  Previously, the resume function would always reference the collection even if the change stream was created for a db or cluster.