### PR TITLE
Fix meaning of MasterConns metric

### DIFF
--- a/server.go
+++ b/server.go
@@ -530,7 +530,7 @@ func (server *mongoServer) poolShrinker() {
 				}
 			}
 			server.liveSockets = remainSockets
-			stats.shrunkConn(1)
+			stats.shrunkConn(end)
 		}
 		server.Unlock()
 

--- a/server.go
+++ b/server.go
@@ -481,7 +481,6 @@ func (server *mongoServer) poolShrinker() {
 				}
 			}
 			server.liveSockets = remainSockets
-			stats.conn(-1*end, server.info.Master)
 		}
 		server.Unlock()
 

--- a/server.go
+++ b/server.go
@@ -481,6 +481,7 @@ func (server *mongoServer) poolShrinker() {
 				}
 			}
 			server.liveSockets = remainSockets
+			stats.shrunkConn(1)
 		}
 		server.Unlock()
 

--- a/socket.go
+++ b/socket.go
@@ -381,6 +381,9 @@ func (socket *mongoSocket) kill(err error, abend bool) {
 	socket.dead = err
 	socket.conn.Close()
 	stats.socketsAlive(-1)
+	if abend {
+		stats.failedConn(1)
+	}
 	replyFuncs := socket.replyFuncs
 	socket.replyFuncs = make(map[uint32]replyFunc)
 	server := socket.server

--- a/stats.go
+++ b/stats.go
@@ -84,6 +84,8 @@ type Stats struct {
 	SentOps             int
 	ReceivedOps         int
 	ReceivedDocs        int
+	ShrunkConns         int
+	FailedConns         int
 	SocketsAlive        int
 	SocketsInUse        int
 	SocketRefs          int
@@ -157,6 +159,22 @@ func (stats *Stats) socketRefs(delta int) {
 	if stats != nil {
 		statsMutex.Lock()
 		stats.SocketRefs += delta
+		statsMutex.Unlock()
+	}
+}
+
+func (stats *Stats) shrunkConn(delta int) {
+	if stats != nil {
+		statsMutex.Lock()
+		stats.ShrunkConns += delta
+		statsMutex.Unlock()
+	}
+}
+
+func (stats *Stats) failedConn(delta int) {
+	if stats != nil {
+		statsMutex.Lock()
+		stats.FailedConns += delta
 		statsMutex.Unlock()
 	}
 }


### PR DESCRIPTION
While exploring some of the mgo metrics around connections opening/closing, I noticed that the MasterConns metric, which I assume is _supposed_ to be an always-incrementing counter, actually gets decremented in the connection pool shrinking logic.

I assume that this is a mistake because other places that can reduce the count of open master connections, such as `kill()` in `abend` error scenarios, don't also decrease this number.

To replace the change in MasterConns metric that the pool shrinker was previously doing, I added its own counter to measure what's happening there (ShrunkConns).

I also added a counter for connections that failed abnormally (FailedConns). This is data that I'm quite curious to get my hands on to debug our Mongo deployment because we're seeing a scenario where there are a lot of connection failures in our setup and a huge churn in connections getting opened/closed.