### PR TITLE
Change session.DatabaseNames to use the `nameOnly` option (if available)

### DIFF
--- a/session.go
+++ b/session.go
@@ -4180,7 +4180,7 @@ type dbNames struct {
 // DatabaseNames returns the names of non-empty databases present in the cluster.
 func (s *Session) DatabaseNames() (names []string, err error) {
 	var result dbNames
-	err = s.Run("listDatabases", &result)
+	err = s.Run(bson.D{{Name: "listDatabases", Value: 1}, {Name: "nameOnly", Value: true}}, &result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
listDatabases by default returns the list of database names as well as
some stats about the database (size, etc.). To gather the stats mongod
acquires a db level lock, which is very slow (and depending on other
locks etc. may cause this to unnecessarily fail).

Perf comparison:
```
basic took 2.772775182s
nameonly took 93.680166ms
```

I have also tested that this additional option falls back to the
previous behavior on mongo <3.6

Mongo docs: https://docs.mongodb.com/manual/reference/command/listDatabases/