### PR TITLE
Implement encoding.TextMarshaler (and TextUnmarshaler) for Decimal128

### DIFF
--- a/bson/decimal.go
+++ b/bson/decimal.go
@@ -310,3 +310,17 @@ func muladd(h, l uint64, mul uint32, add uint32) (resh, resl uint64, overflow ui
 
 	return (d<<32 | c&(1<<32-1)), (b<<32 | a&(1<<32-1)), uint32(d >> 32)
 }
+
+// MarshalText returns a textual representation of decimal128. Satisfies
+// `encoding.TextMarshaler`.
+func (d Decimal128) MarshalText() (text []byte, err error) {
+	return []byte(d.String()), nil
+}
+
+// UnmarshalText unmarshals decimal128 from a textual representation. Satisfies
+// `encoding.TextUnmarshaler`.
+func (d *Decimal128) UnmarshalText(text []byte) error {
+	var err error
+	*d, err = ParseDecimal128(string(text))
+	return err
+}

--- a/bson/decimal_test.go
+++ b/bson/decimal_test.go
@@ -145,6 +145,14 @@ func (s *S) TestDecimalTests(c *C) {
 			data, err = bson.Marshal(parsedValue)
 			c.Assert(err, IsNil)
 			c.Assert(hex.EncodeToString(data), Equals, test.BSON)
+
+			// Check that implemented `encoding.TextMarshaler` leads to working json encoding.
+			jsonBytes, err := json.Marshal(dec128)
+			c.Assert(err, IsNil)
+			var newDec128 bson.Decimal128
+			err = json.Unmarshal(jsonBytes, &newDec128)
+			c.Assert(err, IsNil)
+			c.Assert(newDec128, Equals, dec128)
 		}
 
 		for _, test := range tests.ParseErrors {


### PR DESCRIPTION
Currently Decimal128 can't be converted to the JSON directly w/o additional actions.

Implementing `encoding.TextMarshaler` interface can make a type useful in multiple encodings.
Packages that check for these interfaces include `encoding/gob`, `encoding/json`, `encoding/xml` and many other custom ones.

Closes #350
