### PR TITLE
Fix debugf arguments

### DIFF
--- a/gridfs.go
+++ b/gridfs.go
@@ -678,7 +678,7 @@ func (file *GridFile) insertChunk(data []byte) {
 // an error, if any.
 func (file *GridFile) Seek(offset int64, whence int) (pos int64, err error) {
 	file.m.Lock()
-	debugf("GridFile %p: seeking for %s (whence=%d)", file, offset, whence)
+	debugf("GridFile %p: seeking for %d (whence=%d)", file, offset, whence)
 	defer file.m.Unlock()
 	switch whence {
 	case os.SEEK_SET:

--- a/session.go
+++ b/session.go
@@ -94,7 +94,7 @@ const (
 // All Session methods are concurrency-safe and may be called from multiple
 // goroutines. In all session modes but Eventual, using the session from
 // multiple goroutines will cause them to share the same underlying socket.
-// See the documentation on Session.SetMode for more details.
+// See the documentation on Session.SetMode for more details.git@github.com:eclipseo/mgo.git
 type Session struct {
 	defaultdb        string
 	sourcedb         string
@@ -3885,7 +3885,7 @@ func (db *Database) run(socket *mongoSocket, cmd, result interface{}) (err error
 	if result != nil {
 		err = bson.Unmarshal(data, result)
 		if err != nil {
-			debugf("Run command unmarshaling failed: %#v", op, err)
+			debugf("Run command unmarshaling failed: %#v, error: %#v", op, err)
 			return err
 		}
 		if globalDebug && globalLogger != nil {


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

```
Testing in: /builddir/build/BUILD/mgo-r2018.06.15/_build/src
      PATH: /builddir/build/BUILD/mgo-r2018.06.15/_build/bin:/builddir/.local/bin:/builddir/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin
    GOPATH: /builddir/build/BUILD/mgo-r2018.06.15/_build:/usr/share/gocode
   command: go test -buildmode pie -compiler gc -ldflags "-X github.com/globalsign/mgo/version=r2018.06.15 -X github.com/globalsign/mgo/version.tag=r2018.06.15 -extldflags '-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '"
   testing: github.com/globalsign/mgo
github.com/globalsign/mgo
# github.com/globalsign/mgo
./gridfs.go:681:2: debugf format %s has arg offset of wrong type int64
./session.go:3888:4: debugf call needs 1 arg but has 2 args
FAIL	github.com/globalsign/mgo [build failed]
```