### PR TITLE
add support for "objectid" bson flag string and string pointer

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -659,7 +659,7 @@ func (raw Raw) Unmarshal(out interface{}) (err error) {
 		fallthrough
 	case reflect.Map:
 		d := newDecoder(raw.Data)
-		good := d.readElemTo(v, raw.Kind)
+		good := d.readElemTo(v, raw.Kind, nil)
 		if !good {
 			return &TypeError{v.Type(), raw.Kind}
 		}
@@ -696,6 +696,7 @@ type fieldInfo struct {
 	Key       string
 	Num       int
 	OmitEmpty bool
+	ObjectId  bool
 	MinSize   bool
 	Inline    []int
 }
@@ -759,6 +760,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					info.MinSize = true
 				case "inline":
 					inline = true
+				case "objectid":
+					info.ObjectId = true
 				default:
 					msg := fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st)
 					panic(externalPanic(msg))

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -234,7 +234,7 @@ func (d *decoder) readDocTo(out reflect.Value) {
 		switch outk {
 		case reflect.Map:
 			e := reflect.New(elemType).Elem()
-			if d.readElemTo(e, kind) {
+			if d.readElemTo(e, kind, nil) {
 				k := reflect.ValueOf(name)
 				if convertKey {
 					mapKeyType := out.Type().Key()
@@ -279,16 +279,16 @@ func (d *decoder) readDocTo(out reflect.Value) {
 		case reflect.Struct:
 			if info, ok := fieldsMap[name]; ok {
 				if info.Inline == nil {
-					d.readElemTo(out.Field(info.Num), kind)
+					d.readElemTo(out.Field(info.Num), kind, &info)
 				} else {
-					d.readElemTo(out.FieldByIndex(info.Inline), kind)
+					d.readElemTo(out.FieldByIndex(info.Inline), kind, nil)
 				}
 			} else if inlineMap.IsValid() {
 				if inlineMap.IsNil() {
 					inlineMap.Set(reflect.MakeMap(inlineMap.Type()))
 				}
 				e := reflect.New(elemType).Elem()
-				if d.readElemTo(e, kind) {
+				if d.readElemTo(e, kind, nil) {
 					inlineMap.SetMapIndex(reflect.ValueOf(name), e)
 				}
 			} else {
@@ -338,7 +338,7 @@ func (d *decoder) readArrayDocTo(out reflect.Value) {
 			corrupted()
 		}
 		d.i++
-		d.readElemTo(out.Index(i), kind)
+		d.readElemTo(out.Index(i), kind, nil)
 		if d.i >= end {
 			corrupted()
 		}
@@ -379,7 +379,7 @@ func (d *decoder) readSliceDoc(t reflect.Type) interface{} {
 		}
 		d.i++
 		e := reflect.New(elemType).Elem()
-		if d.readElemTo(e, kind) {
+		if d.readElemTo(e, kind, nil) {
 			tmp = append(tmp, e)
 		}
 		if d.i >= end {
@@ -554,7 +554,7 @@ func (d *decoder) readDocElems(typ reflect.Type) reflect.Value {
 	d.readDocWith(func(kind byte, name string) {
 		e := DocElem{Name: name}
 		v := reflect.ValueOf(&e.Value)
-		if d.readElemTo(v.Elem(), kind) {
+		if d.readElemTo(v.Elem(), kind, nil) {
 			slice = append(slice, e)
 		}
 	})
@@ -617,7 +617,7 @@ func (d *decoder) dropElem(kind byte) {
 // Attempt to decode an element from the document and put it into out.
 // If the types are not compatible, the returned ok value will be
 // false and out will be unchanged.
-func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
+func (d *decoder) readElemTo(out reflect.Value, kind byte, info *fieldInfo) (good bool) {
 	outt := out.Type()
 
 	if outt == typeRaw {
@@ -808,6 +808,18 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		out.Set(inv)
 		return true
 	case reflect.String:
+		if inv.Type() == typeObjectId {
+			if info != nil && info.ObjectId {
+				inObjId, ok := inv.Interface().(ObjectId)
+				if ok {
+					out.SetString(inObjId.Hex())
+					return true
+				}
+				// should we panic on else?
+			}
+			out.SetString(inv.String())
+			return true
+		}
 		switch inv.Kind() {
 		case reflect.String:
 			out.SetString(inv.String())


### PR DESCRIPTION
This allows us to use the type `string` instead of `ObjectId` in struct fields, so that our struct types are not bson-specific (may want to have xml tags or sql db tags in the same struct for example)

Example:

```
type EventModel struct {
	EventId   string    `bson:"_id,objectid" json:"eventId"`
}
```