### PR TITLE
update: return bulk result if error

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -312,7 +312,7 @@ func (b *Bulk) Run() (*BulkResult, error) {
 	}
 	if failed {
 		sort.Sort(bulkErrorCases(berr.ecases))
-		return nil, &berr
+		return &result, &berr
 	}
 	return &result, nil
 }


### PR DESCRIPTION
For bulk upsert error handling:
if bulkUpsert fail (query not found and couldn't insert new one by index), we cannot get bulk result. it would be helpful if we also get bulk result.