### PR TITLE
[Critical] fix serialization of readConcern

### DIFF
--- a/session.go
+++ b/session.go
@@ -2912,7 +2912,6 @@ func (p *Pipe) SetMaxTime(d time.Duration) *Pipe {
 	return p
 }
 
-
 // Collation allows to specify language-specific rules for string comparison,
 // such as rules for lettercase and accent marks.
 // When specifying collation, the locale field is mandatory; all other collation
@@ -3769,7 +3768,7 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 		AwaitData:       op.flags&flagAwaitData != 0,
 		OplogReplay:     op.flags&flagLogReplay != 0,
 		NoCursorTimeout: op.flags&flagNoCursorTimeout != 0,
-		ReadConcern:     readLevel{level: op.readConcern},
+		ReadConcern:     readLevel{Level: op.readConcern},
 	}
 
 	if op.limit < 0 {
@@ -3838,7 +3837,7 @@ type findCmd struct {
 // readLevel provides the nested "level: majority" serialisation needed for the
 // query read concern.
 type readLevel struct {
-	level string `bson:"level,omitempty"`
+	Level string `bson:"level,omitempty"`
 }
 
 // getMoreCmd holds the command used for requesting more query results on MongoDB 3.2+.

--- a/session.go
+++ b/session.go
@@ -3788,6 +3788,7 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	op.hasOptions = false
 
 	if explain {
+		find.ReadConcern.Level = ""
 		op.query = bson.D{{Name: "explain", Value: op.query}}
 		return false
 	}


### PR DESCRIPTION
Private field `level` were not serialized to BSON, therefore it were
never sent to mongos/mongod.

Make it public.