### PR TITLE
[Critical] Fix map[key]value, when key is uint64, it will overflow

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -313,7 +313,7 @@ func (d *decoder) readDocTo(out reflect.Value) {
 func (decoder) parseMapKeyAsUInt64(k reflect.Value, mapKeyKind reflect.Kind) uint64 {
 	parsed, err := strconv.ParseUint(k.String(), 10, 64)
 	if err != nil {
-		panic("Map key is defined to be a decimal type (" + mapKeyKind.String() + ") but got error " +
+		panic("Map key is defined to be an integer type (" + mapKeyKind.String() + ") but got error " +
 			err.Error())
 	}
 

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -250,7 +250,8 @@ func (d *decoder) readDocTo(out reflect.Value) {
 					case reflect.Int32:
 						fallthrough
 					case reflect.Int64:
-						fallthrough
+						parsed := d.parseMapKeyAsInt64(k, mapKeyKind)
+						k = reflect.ValueOf(parsed)
 					case reflect.Uint:
 						fallthrough
 					case reflect.Uint8:
@@ -260,7 +261,8 @@ func (d *decoder) readDocTo(out reflect.Value) {
 					case reflect.Uint32:
 						fallthrough
 					case reflect.Uint64:
-						fallthrough
+						parsed := d.parseMapKeyAsUInt64(k, mapKeyKind)
+						k = reflect.ValueOf(parsed)
 					case reflect.Float32:
 						fallthrough
 					case reflect.Float64:
@@ -306,6 +308,26 @@ func (d *decoder) readDocTo(out reflect.Value) {
 		corrupted()
 	}
 	d.docType = docType
+}
+
+func (decoder) parseMapKeyAsUInt64(k reflect.Value, mapKeyKind reflect.Kind) uint64 {
+	parsed, err := strconv.ParseUint(k.String(), 10, 64)
+	if err != nil {
+		panic("Map key is defined to be a decimal type (" + mapKeyKind.String() + ") but got error " +
+			err.Error())
+	}
+
+	return parsed
+}
+
+func (decoder) parseMapKeyAsInt64(k reflect.Value, mapKeyKind reflect.Kind) int64 {
+	parsed, err := strconv.ParseInt(k.String(), 10, 64)
+	if err != nil {
+		panic("Map key is defined to be a decimal type (" + mapKeyKind.String() + ") but got error " +
+			err.Error())
+	}
+
+	return parsed
 }
 
 func (decoder) parseMapKeyAsFloat(k reflect.Value, mapKeyKind reflect.Kind) float64 {

--- a/bson/decode.go
+++ b/bson/decode.go
@@ -323,7 +323,7 @@ func (decoder) parseMapKeyAsUInt64(k reflect.Value, mapKeyKind reflect.Kind) uin
 func (decoder) parseMapKeyAsInt64(k reflect.Value, mapKeyKind reflect.Kind) int64 {
 	parsed, err := strconv.ParseInt(k.String(), 10, 64)
 	if err != nil {
-		panic("Map key is defined to be a decimal type (" + mapKeyKind.String() + ") but got error " +
+		panic("Map key is defined to be an integer type (" + mapKeyKind.String() + ") but got error " +
 			err.Error())
 	}
 


### PR DESCRIPTION
for example
```golang
package mongo_test_test

import (
	"encoding/json"
	"fmt"
	"github.com/globalsign/mgo/bson"
	"math"
	"testing"
)

func Stringify(o interface{}) string {
	data, err := json.Marshal(o)
	if err != nil {
		return err.Error()
	}
	return string(data)
}

type Data struct {
	Type int32             `bson:"Type"`
	Data map[uint64]string `bson:"Data"`
}

func TestBsonMap(t *testing.T) {
	mapData := make(map[uint64]string)

	numInt64 := uint64(math.MaxUint64)
	mapData[numInt64] = "a"
	data := &Data{
		Type: 100,
		Data: mapData,
	}
	byteData, err := bson.Marshal(data)
	if err != nil {
		fmt.Println(err)
	}

	var after = &Data{}
	err = bson.Unmarshal(byteData, after)
	fmt.Printf("%d\n", numInt64)
	fmt.Printf("%s\n", Stringify(after))
}

```


```golang
// the output should be:
// 18446744073709551615
// {"Type":100,"Data":{"18446744073709551615":"a"}}


// but got:
// 18446744073709551615
// {"Type":100,"Data":{"9223372036854775808":"a"}}
```