### PR TITLE
Update Dial docs with already supported query params

### DIFF
--- a/session.go
+++ b/session.go
@@ -304,6 +304,18 @@ const (
 //        false: Initiate the connection without TLS/SSL.
 //        The default value is false.
 //
+//     w=<wmode>
+//
+//         Write mode for MongoDB 2.0+ (e.g. "majority").
+//
+//     j=<true|false>
+//
+//         Sync via the journal if present
+//
+//     readPreference=<nearest|primary|primaryPreferred|secondary|secondaryPreferred>
+//
+//         Read preference mode. See Mode for details.
+//
 // Relevant documentation:
 //
 //     http://docs.mongodb.org/manual/reference/connection-string/
@@ -341,19 +353,19 @@ func ParseURL(url string) (*DialInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	ssl := false
-	direct := false
-	mechanism := ""
-	service := ""
-	source := ""
-	setName := ""
-	poolLimit := 0
-	appName := ""
-	readPreferenceMode := Primary
-	var readPreferenceTagSets []bson.D
-	minPoolSize := 0
-	maxIdleTimeMS := 0
-	safe := Safe{}
+	ssl := false // ssl
+	direct := false  // connect
+	mechanism := "" // authMechanism
+	service := "" // gssapiServiceNname
+	source := "" // authSource
+	setName := "" // replicaSet
+	poolLimit := 0 // maxPoolSize
+	appName := "" // appName
+	readPreferenceMode := Primary // readPreference
+	var readPreferenceTagSets []bson.D // readPreferenceTags
+	minPoolSize := 0 // minPoolSize
+	maxIdleTimeMS := 0 // maxIdleTimeMS
+	safe := Safe{} // w/j
 	for _, opt := range uinfo.options {
 		switch opt.key {
 		case "ssl":


### PR DESCRIPTION
The driver currently doesn't mention three parameters that it exposes in the DSN. 

This PR makes no code changes, but simply updates the docs so future folks don't have to go digging.

Thanks!