### PR TITLE
Implement "omitalways" tag to allow decode yet prevent encode.

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -552,6 +552,10 @@ func handleErr(err *error) {
 //     omitempty  Only include the field if it's not set to the zero
 //                value for the type or to empty slices or maps.
 //
+//     omitalways Never include the field. This is most useful for
+//                embedded structs that should be decoded, but never
+//                encoded.
+//
 //     minsize    Marshal an int64 value as an int32, if that's feasible
 //                while preserving the numeric value.
 //
@@ -564,11 +568,12 @@ func handleErr(err *error) {
 //
 //     type T struct {
 //         A bool
-//         B int    "myb"
-//         C string "myc,omitempty"
-//         D string `bson:",omitempty" json:"jsonkey"`
-//         E int64  ",minsize"
-//         F int64  "myf,omitempty,minsize"
+//         B int        "myb"
+//         C string     "myc,omitempty"
+//         D string     `bson:",omitempty" json:"jsonkey"`
+//         E int64      ",minsize"
+//         F int64      "myf,omitempty,minsize"
+//         G CustomType "myg,omitalways"
 //     }
 //
 func Marshal(in interface{}) (out []byte, err error) {
@@ -697,11 +702,12 @@ type structInfo struct {
 }
 
 type fieldInfo struct {
-	Key       string
-	Num       int
-	OmitEmpty bool
-	MinSize   bool
-	Inline    []int
+	Key         string
+	Num         int
+	OmitEmpty   bool
+	OmitAlways  bool
+	MinSize     bool
+	Inline      []int
 }
 
 var structMap = make(map[reflect.Type]*structInfo)
@@ -760,6 +766,8 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				switch strings.TrimSpace(flag) {
 				case "omitempty":
 					info.OmitEmpty = true
+				case "omitalways":
+					info.OmitAlways = true
 				case "minsize":
 					info.MinSize = true
 				case "inline":

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -245,6 +245,9 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.OmitEmpty && isZero(value) {
 			continue
 		}
+		if info.OmitAlways {
+			continue
+		}
 		if useRespectNilValues &&
 			(value.Kind() == reflect.Slice || value.Kind() == reflect.Map) &&
 			value.IsNil() {


### PR DESCRIPTION
A developer may wish to decode or otherwise assign to a struct field but not re-encode. For example, a MongoDB document struct with a struct pointer inside for relationships:
```go
type User struct {
  Email     string    `bson:"email"`
  Sessions  []Session `bson:"sessions,omitalways"`
}
```
This is accomplished via the following set of implementations:
- Implement flag in `fieldInfo` struct.
- Implement flag detection and assignment to `fieldInfo` struct.
- Implement skip-encode on flag true.
- Implement documentation and examples.