### PR TITLE
Porting mongo+srv support from new, offical mongo driver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,20 @@ We really appreciate contributions, but they must meet the following requirement
 We merge PRs into `development`, which is then tested in a sharded, replicated environment in our datacenter for regressions. Once everyone is happy, we merge to master - this is to maintain a bit of quality control past the usual PR process.
 
 **Thanks** for helping!
+
+# How to test the code
+In order to run the tests, you need the following installed (assuming Ubuntu)
+
+* daemontools (for svstat)
+* mongo (for mongo client)
+* mongodb (for mongo server)
+
+Before running the tests, you need to start the test mongo server with `make startdb`. After the tests are done, you
+can tear it down with `make stopdb`.
+
+The tests to run are defined in `.travis.yml` under the *script* section.
+
+## Note about DNS Lookup of SRV records
+If you are testing on Linux, you may run into an error that net.LookupSRV cannot parse the DNS response.
+In this case, you are likely using a distribution that uses systemd for DNS and go does not handle it yet.
+The easiest work around is to change your /etc/resolv.conf file and set a remote nameserver; 8.8.8.8 or 9.9.9.9.

--- a/session_test.go
+++ b/session_test.go
@@ -233,6 +233,35 @@ func (s *S) TestURLInvalidSafe(c *C) {
 	}
 }
 
+// it is difficult to set up a service record on demand as it requires new DNS entries.
+// This cannot just be done using an /etc/hosts file modification.
+// This test will be disabled by default. If you want to test the code
+// that performs a mongo connection using a DNS SVR (service) record,
+// you will need to set that up yourself. I would recommend using a free tier
+// of Mongo Atlas for the test.
+//
+// For more information, please see
+// https://www.mongodb.com/blog/post/mongodb-3-6-here-to-SRV-you-with-easier-replica-set-connections.
+func (s *S) TestURLMongoServiceRecord(c *C) {
+	c.Skip("Requires DNS configuration / Atlas")
+	url := "mongodb+srv://<username>:<password>@<host>.mongodb.net/<db>?ssl=true"
+	dialInfo, err := mgo.ParseURL(url)
+	c.Assert(err, IsNil)
+
+	session, err := mgo.DialWithInfo(dialInfo)
+	c.Assert(err, IsNil)
+
+	defer session.Close()
+
+	db := session.DB("id")
+
+	var result map[string]interface{}
+
+	err = db.C("<collection>").Find(nil).Sort("-_id").One(&result)
+	c.Assert(err, IsNil)
+	c.Assert(len(result), Not(Equals), 0)
+}
+
 func (s *S) TestURLUnixSocket(c *C) {
 	type test struct {
 		url      string


### PR DESCRIPTION
This PR is to address issue #112 . The code changes are largely based on the new, official mongo driver. That code does not drop in cleanly, so the code was modified so that it works with mgo.

While a test does exist, it requires specific DNS configurations that have to be set up externally. This test can be modified to enable testing a connection to a cluster using the new mongo+srv URI format.